### PR TITLE
Filter the library by city, add a neighbourhood, retire the free-text…

### DIFF
--- a/backend/Talmidon.Api/Contracts/TeacherDtos.cs
+++ b/backend/Talmidon.Api/Contracts/TeacherDtos.cs
@@ -6,11 +6,11 @@ public record UpdateTeacherProfileRequest(
     [MaxLength(40)] string? Phone,
     [EmailAddress, MaxLength(256)] string? ContactEmail,
     [MaxLength(100)] string? City,
+    [MaxLength(100)] string? Neighborhood,
     [MaxLength(2000)] string? Bio,
     [Range(0, double.MaxValue)] decimal DefaultPricePerLesson,
     [Range(1, 1440)] int DefaultDurationMinutes,
     [MaxLength(4000)] string? RulesText,
-    [MaxLength(1000)] string? ContactInfo,
     bool IsPublic);
 
 /// <summary>חלון זמינות שבועי. DayOfWeek: ראשון=0 ... שבת=6. שעות בפורמט "HH:mm".</summary>
@@ -39,11 +39,11 @@ public record TeacherProfileDto(
     string? Phone,
     string? ContactEmail,
     string? City,
+    string? Neighborhood,
     string? Bio,
     decimal DefaultPricePerLesson,
     int DefaultDurationMinutes,
     string? RulesText,
-    string? ContactInfo,
     bool IsPublic,
     List<SubjectDto> Subjects,
     /// <summary>
@@ -60,6 +60,7 @@ public record PublicTeacherSummaryDto(
     string FullName,
     string? Bio,
     string? City,
+    string? Neighborhood,
     decimal DefaultPricePerLesson,
     List<string> Subjects,
     int? PhotoVersion);
@@ -73,10 +74,10 @@ public record PublicTeacherDetailDto(
     string FullName,
     string? Bio,
     string? City,
+    string? Neighborhood,
     string? Phone,
     string? ContactEmail,
     decimal DefaultPricePerLesson,
     string? RulesText,
-    string? ContactInfo,
     List<string> Subjects,
     int? PhotoVersion);

--- a/backend/Talmidon.Api/Controllers/PublicController.cs
+++ b/backend/Talmidon.Api/Controllers/PublicController.cs
@@ -22,19 +22,21 @@ public class PublicController(
 {
     [HttpGet]
     public async Task<ActionResult<IEnumerable<PublicTeacherSummaryDto>>> List(
-        [FromQuery] string? subject, [FromQuery] string? search)
+        [FromQuery] string? subject, [FromQuery] string? city, [FromQuery] string? search)
     {
         var query = db.Teachers.Where(t => t.IsPublic);
 
         if (!string.IsNullOrWhiteSpace(subject))
             query = query.Where(t => t.Subjects.Any(s => s.Name == subject));
+        if (!string.IsNullOrWhiteSpace(city))
+            query = query.Where(t => t.City == city);
         if (!string.IsNullOrWhiteSpace(search))
             query = query.Where(t => t.FullName.Contains(search));
 
         var teachers = await query
             .OrderBy(t => t.FullName)
             .Select(t => new PublicTeacherSummaryDto(
-                t.Id, t.FullName, t.Bio, t.City, t.DefaultPricePerLesson,
+                t.Id, t.FullName, t.Bio, t.City, t.Neighborhood, t.DefaultPricePerLesson,
                 t.Subjects.Select(s => s.Name).ToList(),
                 // רק אורך, לא ה-blob: אחרת כל טעינה של הספרייה הייתה מושכת את כל
                 // התמונות בתוך ה-JSON. הלקוח בונה מזה את הכתובת.
@@ -54,6 +56,19 @@ public class PublicController(
             .OrderBy(s => s)
             .ToListAsync();
         return Ok(subjects);
+    }
+
+    /// <summary>הערים שיש בהן מורות ציבוריות — לתפריט הסינון. ריקות אינן נספרות.</summary>
+    [HttpGet("cities")]
+    public async Task<ActionResult<IEnumerable<string>>> ListCities()
+    {
+        var cities = await db.Teachers
+            .Where(t => t.IsPublic && t.City != null && t.City != "")
+            .Select(t => t.City!)
+            .Distinct()
+            .OrderBy(c => c)
+            .ToListAsync();
+        return Ok(cities);
     }
 
     /// <summary>
@@ -80,8 +95,8 @@ public class PublicController(
         var teacher = await db.Teachers
             .Where(t => t.Id == id && t.IsPublic)
             .Select(t => new PublicTeacherDetailDto(
-                t.Id, t.FullName, t.Bio, t.City, t.Phone, t.ContactEmail,
-                t.DefaultPricePerLesson, t.RulesText, t.ContactInfo,
+                t.Id, t.FullName, t.Bio, t.City, t.Neighborhood, t.Phone, t.ContactEmail,
+                t.DefaultPricePerLesson, t.RulesText,
                 t.Subjects.Select(s => s.Name).ToList(),
                 t.PhotoData == null ? (int?)null : t.PhotoData.Length))
             .FirstOrDefaultAsync();

--- a/backend/Talmidon.Api/Controllers/TeachersController.cs
+++ b/backend/Talmidon.Api/Controllers/TeachersController.cs
@@ -38,11 +38,11 @@ public class TeachersController(TalmidonDbContext db, ICurrentTenant currentTena
                 t.Phone,
                 t.ContactEmail,
                 t.City,
+                t.Neighborhood,
                 t.Bio,
                 t.DefaultPricePerLesson,
                 t.DefaultDurationMinutes,
                 t.RulesText,
-                t.ContactInfo,
                 t.IsPublic,
                 Subjects = t.Subjects.Select(s => new SubjectDto(s.Id, s.Name)).ToList(),
                 PhotoLength = t.PhotoData == null ? (int?)null : t.PhotoData.Length
@@ -51,14 +51,15 @@ public class TeachersController(TalmidonDbContext db, ICurrentTenant currentTena
         if (row is null) return NotFound();
 
         return Ok(new TeacherProfileDto(
-            row.Id, row.FullName, row.Phone, row.ContactEmail, row.City, row.Bio,
+            row.Id, row.FullName, row.Phone, row.ContactEmail, row.City, row.Neighborhood,
+            row.Bio,
             row.DefaultPricePerLesson,
-            row.DefaultDurationMinutes, row.RulesText, row.ContactInfo, row.IsPublic,
+            row.DefaultDurationMinutes, row.RulesText, row.IsPublic,
             row.Subjects,
             row.PhotoLength,
             TeacherProfileRules.IsComplete(
                 row.Subjects.Count, row.DefaultPricePerLesson,
-                row.Phone, row.ContactEmail, row.ContactInfo)));
+                row.Phone, row.ContactEmail)));
     }
 
     [HttpPut("me")]
@@ -70,11 +71,11 @@ public class TeachersController(TalmidonDbContext db, ICurrentTenant currentTena
         teacher.Phone = request.Phone;
         teacher.ContactEmail = request.ContactEmail;
         teacher.City = request.City;
+        teacher.Neighborhood = request.Neighborhood;
         teacher.Bio = request.Bio;
         teacher.DefaultPricePerLesson = request.DefaultPricePerLesson;
         teacher.DefaultDurationMinutes = request.DefaultDurationMinutes;
         teacher.RulesText = request.RulesText;
-        teacher.ContactInfo = request.ContactInfo;
         teacher.IsPublic = request.IsPublic;
         await db.SaveChangesAsync();
         return NoContent();

--- a/backend/Talmidon.Domain/Entities/Teacher.cs
+++ b/backend/Talmidon.Domain/Entities/Teacher.cs
@@ -23,6 +23,9 @@ public class Teacher
     /// <summary>יישוב. מה שהורה מסנן לפיו קודם כל כשהוא מחפש מורה.</summary>
     public string? City { get; set; }
 
+    /// <summary>שכונה בתוך היישוב. מוצגת לצד העיר; אין סינון לפיה.</summary>
+    public string? Neighborhood { get; set; }
+
     /// <summary>תיאור לדף הציבורי.</summary>
     public string? Bio { get; set; }
 
@@ -35,7 +38,10 @@ public class Teacher
     /// <summary>דף הכללים — כללי ביטול/תשלום.</summary>
     public string? RulesText { get; set; }
 
-    /// <summary>פרטי יצירת קשר לדף הכללים / הספרייה הציבורית.</summary>
+    /// <summary>
+    /// שדה חופשי ישן ליצירת קשר. הוחלף בטלפון, מייל ועיר, ואינו נערך או מוצג
+    /// עוד. העמודה נשארת כדי לא למחוק טקסט שמורות כבר כתבו בה.
+    /// </summary>
     public string? ContactInfo { get; set; }
 
     /// <summary>האם להציג בספרייה הציבורית.</summary>

--- a/backend/Talmidon.Domain/TeacherProfileRules.cs
+++ b/backend/Talmidon.Domain/TeacherProfileRules.cs
@@ -18,13 +18,10 @@ public static class TeacherProfileRules
         int subjectCount,
         decimal defaultPricePerLesson,
         string? phone,
-        string? contactEmail,
-        string? contactInfo) =>
+        string? contactEmail) =>
         subjectCount > 0
         && defaultPricePerLesson > 0
-        // די בדרך אחת ליצור קשר. הטופס מציע טלפון, מייל והערה חופשית, ומורה
-        // שמילאה אחד מהם אינה אמורה להיתקע במסך ההקמה בגלל השניים האחרים.
-        && (!string.IsNullOrWhiteSpace(phone)
-            || !string.IsNullOrWhiteSpace(contactEmail)
-            || !string.IsNullOrWhiteSpace(contactInfo));
+        // די בדרך אחת ליצור קשר, ומורה שמילאה אחת מהן אינה אמורה להיתקע
+        // במסך ההקמה בגלל השנייה.
+        && (!string.IsNullOrWhiteSpace(phone) || !string.IsNullOrWhiteSpace(contactEmail));
 }

--- a/backend/Talmidon.Infrastructure/Data/Migrations/20260906180000_AddTeacherNeighborhood.Designer.cs
+++ b/backend/Talmidon.Infrastructure/Data/Migrations/20260906180000_AddTeacherNeighborhood.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Talmidon.Infrastructure.Data;
@@ -11,9 +12,11 @@ using Talmidon.Infrastructure.Data;
 namespace Talmidon.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(TalmidonDbContext))]
-    partial class TalmidonDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260906180000_AddTeacherNeighborhood")]
+    partial class AddTeacherNeighborhood
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Talmidon.Infrastructure/Data/Migrations/20260906180000_AddTeacherNeighborhood.cs
+++ b/backend/Talmidon.Infrastructure/Data/Migrations/20260906180000_AddTeacherNeighborhood.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Talmidon.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTeacherNeighborhood : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Neighborhood",
+                table: "Teachers",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Neighborhood",
+                table: "Teachers");
+        }
+    }
+}

--- a/backend/Talmidon.Infrastructure/Data/TalmidonDbContext.cs
+++ b/backend/Talmidon.Infrastructure/Data/TalmidonDbContext.cs
@@ -92,6 +92,7 @@ public class TalmidonDbContext : IdentityDbContext<ApplicationUser>
             e.Property(t => t.Phone).HasMaxLength(40);
             e.Property(t => t.ContactEmail).HasMaxLength(256);
             e.Property(t => t.City).HasMaxLength(100);
+            e.Property(t => t.Neighborhood).HasMaxLength(100);
             e.Property(t => t.Bio).HasMaxLength(2000);
             e.Property(t => t.RulesText).HasMaxLength(4000);
             e.Property(t => t.ContactInfo).HasMaxLength(1000);

--- a/frontend/src/app/features/public/public.models.ts
+++ b/frontend/src/app/features/public/public.models.ts
@@ -3,6 +3,7 @@ export interface PublicTeacherSummary {
   fullName: string;
   bio: string | null;
   city: string | null;
+  neighborhood: string | null;
   defaultPricePerLesson: number;
   subjects: string[];
   photoVersion: number | null;
@@ -13,11 +14,11 @@ export interface PublicTeacherDetail {
   fullName: string;
   bio: string | null;
   city: string | null;
+  neighborhood: string | null;
   phone: string | null;
   contactEmail: string | null;
   defaultPricePerLesson: number;
   rulesText: string | null;
-  contactInfo: string | null;
   subjects: string[];
   photoVersion: number | null;
 }

--- a/frontend/src/app/features/public/public.service.ts
+++ b/frontend/src/app/features/public/public.service.ts
@@ -17,6 +17,10 @@ export class PublicService {
     return this.http.get<string[]>(`${this.api}/subjects`);
   }
 
+  listCities(): Observable<string[]> {
+    return this.http.get<string[]>(`${this.api}/cities`);
+  }
+
   getTeacher(id: string): Observable<PublicTeacherDetail> {
     return this.http.get<PublicTeacherDetail>(`${this.api}/${id}`);
   }

--- a/frontend/src/app/features/public/teacher-library/teacher-library.component.html
+++ b/frontend/src/app/features/public/teacher-library/teacher-library.component.html
@@ -45,8 +45,18 @@
         (ngModelChange)="selectedSubject.set($event)"
         placeholder="כל התחומים"
         [showClear]="true"
-        style="min-width: 200px"
+        style="min-width: 170px"
       />
+      @if (cities().length > 0) {
+        <p-select
+          [options]="cities()"
+          [ngModel]="selectedCity()"
+          (ngModelChange)="selectedCity.set($event)"
+          placeholder="כל הערים"
+          [showClear]="true"
+          style="min-width: 170px"
+        />
+      }
     </div>
 
     @if (!loading() && allTeachers().length > 0) {
@@ -119,8 +129,8 @@
               <app-avatar [name]="teacher.fullName" [photoUrl]="photoUrl(teacher.id, teacher.photoVersion)" />
               <div>
                 <h3 class="m-0">{{ teacher.fullName }}</h3>
-                @if (teacher.city; as city) {
-                  <span class="teacher-card-city"><i class="pi pi-map-marker"></i> {{ city }}</span>
+                @if (teacherLocation(teacher); as place) {
+                  <span class="teacher-card-city"><i class="pi pi-map-marker"></i> {{ place }}</span>
                 }
               </div>
             </div>

--- a/frontend/src/app/features/public/teacher-library/teacher-library.component.ts
+++ b/frontend/src/app/features/public/teacher-library/teacher-library.component.ts
@@ -54,7 +54,7 @@ export class TeacherLibraryComponent implements OnInit {
    * מתחת לשדה החיפוש, ובלי מספר לא ברור אם המסנן בכלל תפס.
    */
   protected readonly resultsTitle = computed(() => {
-    if (!this.search().trim() && !this.selectedSubject()) return 'המורות שלנו';
+    if (!this.search().trim() && !this.selectedSubject() && !this.selectedCity()) return 'המורות שלנו';
     const count = this.teachers().length;
     if (count === 0) return 'לא נמצאו מורות';
     return count === 1 ? 'נמצאה מורה אחת' : `נמצאו ${count} מורות`;
@@ -101,6 +101,17 @@ export class TeacherLibraryComponent implements OnInit {
   protected readonly subjects = signal<string[]>([]);
   protected readonly search = signal('');
   protected readonly selectedSubject = signal<string | null>(null);
+  protected readonly selectedCity = signal<string | null>(null);
+
+  /**
+   * הערים נגזרות מהמורות שנטענו ולא מקריאה נפרדת: הסינון עצמו מקומי, ורשימה
+   * שמגיעה ממקור אחר עלולה להציע עיר שאין לה תוצאה ברשימה שעל המסך.
+   */
+  protected readonly cities = computed(() =>
+    [...new Set(this.allTeachers().map(t => t.city).filter((c): c is string => !!c))].sort((a, b) =>
+      a.localeCompare(b, 'he')
+    )
+  );
 
   /** המחיר הזול ביותר בספרייה — מוצג כ"החל מ־" ברצועת הפתיחה. */
   protected readonly lowestPrice = computed(() => {
@@ -111,10 +122,12 @@ export class TeacherLibraryComponent implements OnInit {
   protected readonly teachers = computed(() => {
     const search = this.search().trim().toLowerCase();
     const subject = this.selectedSubject();
+    const city = this.selectedCity();
     return this.allTeachers().filter(
       teacher =>
         (!search || teacher.fullName.toLowerCase().includes(search)) &&
-        (!subject || teacher.subjects.includes(subject))
+        (!subject || teacher.subjects.includes(subject)) &&
+        (!city || teacher.city === city)
     );
   });
 
@@ -129,9 +142,15 @@ export class TeacherLibraryComponent implements OnInit {
     this.publicService.listSubjects().subscribe(subjects => this.subjects.set(subjects));
   }
 
+  /** "שכונה, עיר" על הכרטיס — מה שיש, בלי פסיק מיותם. */
+  protected teacherLocation(teacher: PublicTeacherSummary): string | null {
+    return [teacher.neighborhood, teacher.city].filter(Boolean).join(', ') || null;
+  }
+
   protected clearFilters(): void {
     this.search.set('');
     this.selectedSubject.set(null);
+    this.selectedCity.set(null);
   }
 
   /**

--- a/frontend/src/app/features/public/teacher-profile/teacher-profile.component.html
+++ b/frontend/src/app/features/public/teacher-profile/teacher-profile.component.html
@@ -49,8 +49,8 @@
         <app-avatar [name]="teacher()!.fullName" [photoUrl]="photoUrl(teacher()!.id, teacher()!.photoVersion)" size="lg" />
         <div class="flex-1">
           <h2>{{ teacher()!.fullName }}</h2>
-          @if (teacher()!.city; as city) {
-            <p class="profile-hero-city"><i class="pi pi-map-marker"></i> {{ city }}</p>
+          @if (location(); as place) {
+            <p class="profile-hero-city"><i class="pi pi-map-marker"></i> {{ place }}</p>
           }
           <div class="flex gap-2 flex-wrap">
             @for (subject of teacher()!.subjects; track subject) {
@@ -107,9 +107,6 @@
                   <i class="pi pi-envelope"></i>
                   <a [href]="'mailto:' + email">{{ email }}</a>
                 </li>
-              }
-              @if (teacher()!.contactInfo; as note) {
-                <li class="profile-contact-note" style="white-space: pre-line">{{ note }}</li>
               }
             </ul>
           } @else {

--- a/frontend/src/app/features/public/teacher-profile/teacher-profile.component.ts
+++ b/frontend/src/app/features/public/teacher-profile/teacher-profile.component.ts
@@ -33,10 +33,16 @@ import { PublicService } from '../public.service';
 export class TeacherProfileComponent implements OnInit {
   private readonly auth = inject(AuthService);
   /** יעד החזרה כשמישהי מחוברת, ו-null כשלא — הכותרת נגזרת מזה. */
-  /** האם יש בכלל מה להציג תחת "יצירת קשר" — שלושת השדות אופציונליים. */
+  /** "שכונה, עיר" כשיש שתיהן, ואחת מהן לבדה כשאין. */
+  protected readonly location = computed(() => {
+    const t = this.teacher();
+    return [t?.neighborhood, t?.city].filter(Boolean).join(', ') || null;
+  });
+
+  /** האם יש בכלל מה להציג תחת "יצירת קשר" — שני השדות אופציונליים. */
   protected readonly hasContactDetails = computed(() => {
     const t = this.teacher();
-    return !!(t?.phone || t?.contactEmail || t?.contactInfo);
+    return !!(t?.phone || t?.contactEmail);
   });
 
   protected readonly homePath = computed(() => (this.auth.isAuthenticated() ? this.auth.homePath() : null));

--- a/frontend/src/app/features/teacher/profile-setup/profile-setup.component.html
+++ b/frontend/src/app/features/teacher/profile-setup/profile-setup.component.html
@@ -52,12 +52,22 @@
         }
       </div>
 
-      <div class="field">
-        <label for="s-city">עיר</label>
-        <input pInputText id="s-city" formControlName="city" class="w-full" placeholder="למשל: ירושלים" [invalid]="isInvalid(form.controls.city)" />
-        @if (fieldError(form.controls.city); as msg) {
-          <small class="text-red-500 block mt-1">{{ msg }}</small>
-        }
+      <div class="flex gap-3">
+        <div class="field flex-1">
+          <label for="s-city">עיר</label>
+          <input pInputText id="s-city" formControlName="city" class="w-full" placeholder="למשל: ירושלים" [invalid]="isInvalid(form.controls.city)" />
+          @if (fieldError(form.controls.city); as msg) {
+            <small class="text-red-500 block mt-1">{{ msg }}</small>
+          }
+        </div>
+
+        <div class="field flex-1">
+          <label for="s-neighborhood">שכונה</label>
+          <input pInputText id="s-neighborhood" formControlName="neighborhood" class="w-full" [invalid]="isInvalid(form.controls.neighborhood)" />
+          @if (fieldError(form.controls.neighborhood); as msg) {
+            <small class="text-red-500 block mt-1">{{ msg }}</small>
+          }
+        </div>
       </div>
 
       <div class="flex gap-3">

--- a/frontend/src/app/features/teacher/profile-setup/profile-setup.component.ts
+++ b/frontend/src/app/features/teacher/profile-setup/profile-setup.component.ts
@@ -62,6 +62,7 @@ export class ProfileSetupComponent implements OnInit {
     {
       defaultPricePerLesson: [0, [Validators.required, Validators.min(1)]],
       city: ['', [Validators.maxLength(100)]],
+      neighborhood: ['', [Validators.maxLength(100)]],
       phone: ['', [Validators.maxLength(40)]],
       contactEmail: ['', [Validators.email, Validators.maxLength(256)]],
       bio: ['', [Validators.maxLength(2000)]]
@@ -86,6 +87,7 @@ export class ProfileSetupComponent implements OnInit {
         this.form.patchValue({
           defaultPricePerLesson: profile.defaultPricePerLesson,
           city: profile.city ?? '',
+          neighborhood: profile.neighborhood ?? '',
           phone: profile.phone ?? '',
           contactEmail: profile.contactEmail ?? '',
           bio: profile.bio ?? ''
@@ -147,12 +149,12 @@ export class ProfileSetupComponent implements OnInit {
             phone: raw.phone || null,
             contactEmail: raw.contactEmail || null,
             city: raw.city || null,
+            neighborhood: raw.neighborhood || null,
             bio: raw.bio || null,
             defaultPricePerLesson: raw.defaultPricePerLesson,
-            // המסך הזה אינו עורך משך, כללים או הערת קשר — נשמר מה שכבר קיים
+            // המסך הזה אינו עורך משך או כללים — נשמר מה שכבר קיים
             defaultDurationMinutes: this.loaded()?.defaultDurationMinutes ?? 60,
             rulesText: this.loaded()?.rulesText ?? null,
-            contactInfo: this.loaded()?.contactInfo ?? null,
             isPublic: true
           })
           .subscribe({

--- a/frontend/src/app/features/teacher/profile/profile.component.html
+++ b/frontend/src/app/features/teacher/profile/profile.component.html
@@ -48,12 +48,22 @@
     </div>
 
     <form [formGroup]="form" (ngSubmit)="save()">
-      <div class="field">
-        <label for="t-city">עיר</label>
-        <input pInputText id="t-city" formControlName="city" class="w-full" [invalid]="isInvalid(form.controls.city)" />
-        @if (fieldError(form.controls.city); as msg) {
-          <small class="text-red-500 block mt-1">{{ msg }}</small>
-        }
+      <div class="flex gap-3">
+        <div class="field flex-1">
+          <label for="t-city">עיר</label>
+          <input pInputText id="t-city" formControlName="city" class="w-full" [invalid]="isInvalid(form.controls.city)" />
+          @if (fieldError(form.controls.city); as msg) {
+            <small class="text-red-500 block mt-1">{{ msg }}</small>
+          }
+        </div>
+
+        <div class="field flex-1">
+          <label for="t-neighborhood">שכונה</label>
+          <input pInputText id="t-neighborhood" formControlName="neighborhood" class="w-full" [invalid]="isInvalid(form.controls.neighborhood)" />
+          @if (fieldError(form.controls.neighborhood); as msg) {
+            <small class="text-red-500 block mt-1">{{ msg }}</small>
+          }
+        </div>
       </div>
 
       <div class="flex gap-3">
@@ -122,20 +132,6 @@
         <label for="t-rules">כללי ביטול ותשלום</label>
         <textarea pTextarea id="t-rules" formControlName="rulesText" rows="3" class="w-full" [invalid]="isInvalid(form.controls.rulesText)"></textarea>
         @if (fieldError(form.controls.rulesText); as msg) {
-          <small class="text-red-500 block mt-1">{{ msg }}</small>
-        }
-      </div>
-
-      <div class="field">
-        <label for="t-contact">פרטי יצירת קשר (מוצג בספרייה הציבורית)</label>
-        <textarea
-          pTextarea
-          id="t-contact"
-          formControlName="contactInfo"
-          rows="2"
-          class="w-full"
-          [invalid]="isInvalid(form.controls.contactInfo)"></textarea>
-        @if (fieldError(form.controls.contactInfo); as msg) {
           <small class="text-red-500 block mt-1">{{ msg }}</small>
         }
       </div>

--- a/frontend/src/app/features/teacher/profile/profile.component.ts
+++ b/frontend/src/app/features/teacher/profile/profile.component.ts
@@ -63,11 +63,11 @@ export class TeacherProfileSettingsComponent implements OnInit {
     phone: ['', [Validators.maxLength(40)]],
     contactEmail: ['', [Validators.email, Validators.maxLength(256)]],
     city: ['', [Validators.maxLength(100)]],
+    neighborhood: ['', [Validators.maxLength(100)]],
     bio: ['', [Validators.maxLength(2000)]],
     defaultPricePerLesson: [0, [Validators.required, Validators.min(0)]],
     defaultDurationMinutes: [60, [Validators.required, Validators.min(1), Validators.max(1440)]],
     rulesText: ['', [Validators.maxLength(4000)]],
-    contactInfo: ['', [Validators.maxLength(1000)]],
     isPublic: [true]
   });
 
@@ -124,11 +124,11 @@ export class TeacherProfileSettingsComponent implements OnInit {
         phone: raw.phone || null,
         contactEmail: raw.contactEmail || null,
         city: raw.city || null,
+        neighborhood: raw.neighborhood || null,
         bio: raw.bio || null,
         defaultPricePerLesson: raw.defaultPricePerLesson,
         defaultDurationMinutes: raw.defaultDurationMinutes,
         rulesText: raw.rulesText || null,
-        contactInfo: raw.contactInfo || null,
         isPublic: raw.isPublic
       })
       .subscribe({
@@ -244,11 +244,11 @@ export class TeacherProfileSettingsComponent implements OnInit {
           phone: profile.phone ?? '',
           contactEmail: profile.contactEmail ?? '',
           city: profile.city ?? '',
+          neighborhood: profile.neighborhood ?? '',
           bio: profile.bio ?? '',
           defaultPricePerLesson: profile.defaultPricePerLesson,
           defaultDurationMinutes: profile.defaultDurationMinutes,
           rulesText: profile.rulesText ?? '',
-          contactInfo: profile.contactInfo ?? '',
           isPublic: profile.isPublic
         });
         this.loading.set(false);

--- a/frontend/src/app/features/teacher/profile/profile.models.ts
+++ b/frontend/src/app/features/teacher/profile/profile.models.ts
@@ -16,11 +16,11 @@ export interface TeacherProfile {
   phone: string | null;
   contactEmail: string | null;
   city: string | null;
+  neighborhood: string | null;
   bio: string | null;
   defaultPricePerLesson: number;
   defaultDurationMinutes: number;
   rulesText: string | null;
-  contactInfo: string | null;
   isPublic: boolean;
   subjects: Subject[];
   /** חותם גרסה לתמונה, או null כשאין. הכתובת נבנית ב-teacherPhotoUrl. */
@@ -33,10 +33,10 @@ export interface UpdateTeacherProfileRequest {
   phone?: string | null;
   contactEmail?: string | null;
   city?: string | null;
+  neighborhood?: string | null;
   bio?: string | null;
   defaultPricePerLesson: number;
   defaultDurationMinutes: number;
   rulesText?: string | null;
-  contactInfo?: string | null;
   isPublic: boolean;
 }


### PR DESCRIPTION
… contact box

The free-form contact field is gone from the profile forms and from the public card: phone, email and city say the same thing in a shape a parent can act on. Its column stays, holding whatever teachers already typed there rather than dropping it — nothing reads or writes it now.

Neighbourhood sits beside the city and reads as "neighbourhood, city" wherever a location is shown, with no orphan comma when only one is set.

The city filter is client-side alongside the subject filter, and its options come from the loaded teachers rather than a separate endpoint, so it can never offer a city that matches nothing on screen. The API takes a city parameter and lists its cities too, for callers that page server-side.