### PR TITLE
Point the Documentation section at the screenshots too

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,7 +510,8 @@ persists in the `talmidon_pgdata` named volume regardless.
 ## Documentation
 
 See [docs/](docs/) for the original requirements specification, database schema design,
-and screen/wireframe planning (in Hebrew).
+and screen/wireframe planning (in Hebrew), plus [docs/images/](docs/images/) — the
+screenshots used in the *Screens* section above.
 
 ---
 


### PR DESCRIPTION
`docs/` gained a fourth thing when the screenshots landed, and the Documentation section still listed the original three. A reader following that link could not tell the images were version-controlled, or where to replace one when a screen changes.

One sentence, pointing at `docs/images/` and saying what is in it.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L)_