### PR TITLE
Show the CI status at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 manages her own students, lesson schedule, pedagogical notes, and payments, with a public,
 login-free directory sitting on top so prospective students can discover tutors and reach out.
 
+[![CI](https://github.com/yt314/Talmidon/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yt314/Talmidon/actions/workflows/ci.yml)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4?logo=dotnet&logoColor=white)
 ![Angular](https://img.shields.io/badge/Angular-21-DD0031?logo=angular&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-17-4169E1?logo=postgresql&logoColor=white)


### PR DESCRIPTION
The suite runs on every push and pull request and has been green, but a reader had no way to know that without opening the Actions tab.

The badge links there, and turns red on its own if a run fails — so it stays honest without anyone maintaining it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L)_