### PR TITLE
Build without warnings

### DIFF
--- a/backend/Talmidon.Api/Program.cs
+++ b/backend/Talmidon.Api/Program.cs
@@ -157,10 +157,11 @@ app.UseAuthorization();
 // המורה צריכה ליצור כל שיעור ביד.
 // לוח הבקרה של Hangfire נשאר לפיתוח בלבד; הוא מאמת דרך Cookie ולא מכיר את ה-JWT.
 //
-// השורה הזו נחוצה למרות ש-AddHangfireServer כבר רשום ב-DI: היא זו שמאתחלת את
-// JobStorage.Current, וה-API הסטטי RecurringJob שלמטה קורא ממנו. בלעדיה העלייה
-// נופלת ב-"Current JobStorage instance has not been initialized yet".
-app.UseHangfireServer();
+// ה-API הסטטי RecurringJob שלמטה קורא מ-JobStorage.Current, ובלעדיו העלייה נופלת
+// ב-"Current JobStorage instance has not been initialized yet". השרת עצמו כבר רשום
+// ב-DI דרך AddHangfireServer ורץ כשירות רקע, ולכן נותר רק להצביע על אותו אחסון —
+// במקום UseHangfireServer, שהוא מיושן ומרים שרת שני.
+JobStorage.Current = app.Services.GetRequiredService<JobStorage>();
 
 RecurringJob.AddOrUpdate<MonthlyPaymentReminderJob>(
     "monthly-payment-reminders",

--- a/backend/Talmidon.Tests/JewishCalendarTests.cs
+++ b/backend/Talmidon.Tests/JewishCalendarTests.cs
@@ -121,7 +121,7 @@ public class JewishCalendarTests
     }
 
     private static DateOnly SingleDayWith(string reason, int year) =>
-        Assert.Single(AllDaysIn(year).Where(d => JewishCalendar.NoLessonReason(d) == reason));
+        Assert.Single(AllDaysIn(year), d => JewishCalendar.NoLessonReason(d) == reason);
 
     private static DateOnly FirstDayWith(string reason, int year) =>
         AllDaysIn(year).First(d => JewishCalendar.NoLessonReason(d) == reason);

--- a/backend/Talmidon.Tests/SiteFeedbackTests.cs
+++ b/backend/Talmidon.Tests/SiteFeedbackTests.cs
@@ -28,7 +28,7 @@ public class SiteFeedbackTests(TalmidonWebApplicationFactory factory)
         var admin = await TestHelpers.CreateAuthorizedAdminClientAsync(factory);
         var rows = await admin.GetFromJsonAsync<List<SiteFeedbackDto>>("/api/admin/feedback");
 
-        var saved = Assert.Single(rows!.Where(f => f.Message == marker));
+        var saved = Assert.Single(rows!, f => f.Message == marker);
         Assert.Equal("0501234567", saved.ContactInfo);
         Assert.Equal("https://talmidon.vercel.app/app/lessons", saved.PageUrl);
         Assert.False(saved.IsHandled);
@@ -89,7 +89,7 @@ public class SiteFeedbackTests(TalmidonWebApplicationFactory factory)
 
         var admin = await TestHelpers.CreateAuthorizedAdminClientAsync(factory);
         var open = await admin.GetFromJsonAsync<List<SiteFeedbackDto>>("/api/admin/feedback");
-        var row = Assert.Single(open!.Where(f => f.Message == marker));
+        var row = Assert.Single(open!, f => f.Message == marker);
 
         var handled = await admin.PostAsync($"/api/admin/feedback/{row.Id}/handled", null);
         Assert.Equal(HttpStatusCode.NoContent, handled.StatusCode);


### PR DESCRIPTION
Four warnings on every build, and each one was pointing at something real.

**Hangfire.** `UseHangfireServer` is obsolete and due to be removed in 2.0. It was only still here to set `JobStorage.Current`, which the static `RecurringJob` calls below it read from — the server itself is already registered in DI through `AddHangfireServer` and runs as a hosted service, so the obsolete call was also starting a second one. Setting `JobStorage.Current` from the container does the one thing that was actually needed.

**xUnit (×3).** `Assert.Single` was given an already-filtered sequence. The overload that takes the predicate reports which element it expected when the assertion fails, instead of just saying the collection was empty.

### Verification

- Build: **0 warnings, 0 errors** (was 4 warnings).
- Tests: **148 passed, 0 failed**, against a real PostgreSQL.
- The Hangfire change touches startup, so the API was actually run: it boots with no `JobStorage` error, and all three recurring jobs (`lesson-reminders`, `lesson-series-generation`, `monthly-payment-reminders`) are registered in the Hangfire tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L)_