### PR TITLE
Show lesson times in Israel time, and stop the phone scrolling sideways

### DIFF
--- a/frontend/src/app/core/i18n/israel-date.pipe.ts
+++ b/frontend/src/app/core/i18n/israel-date.pipe.ts
@@ -1,0 +1,51 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/** הפורמטים שבשימוש בממשק. מכוון שיהיה סגור: כל פורמט חדש נוסף כאן במפורש. */
+export type IsraelDateFormat = 'dd/MM/yyyy HH:mm' | 'dd/MM/yyyy' | 'dd/MM HH:mm' | 'HH:mm';
+
+/**
+ * מפרמט תאריך ושעה תמיד לפי שעון ישראל, ולא לפי אזור הזמן של הדפדפן.
+ *
+ * ‎DatePipe‎ של Angular מפרמט לפי אזור הזמן של המכשיר, ולכן אותו שיעור הוצג 18:00
+ * בישראל, 16:00 בלונדון ו-11:00 בניו יורק. המוצר כולו פועל באזור זמן אחד (ראו
+ * ‎AppTimeZone‎ בשרת), ושעת שיעור היא עובדה מקומית — הורה שהטלפון שלו מוגדר לאזור
+ * זמן אחר קיבל שעה שגויה, ויכול היה לפספס שיעור.
+ *
+ * ‎Intl‎ ולא היסט קבוע: הפרמטר ‎timezone‎ של ‎DatePipe‎ מקבל היסט (‎+0300‎) ולא שם אזור,
+ * והיסט קבוע נשבר במעבר שעון קיץ/חורף — בדיוק כמו שקרה בשרת (ראו ‎AppTimeZone.ToUtc‎).
+ */
+@Pipe({ name: 'ilDate' })
+export class IsraelDatePipe implements PipeTransform {
+  private static readonly formatter = new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Asia/Jerusalem',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  });
+
+  transform(
+    value: Date | string | number | null | undefined,
+    format: IsraelDateFormat = 'dd/MM/yyyy HH:mm'
+  ): string | null {
+    if (value === null || value === undefined || value === '') return null;
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) return null;
+
+    const p: Record<string, string> = {};
+    for (const part of IsraelDatePipe.formatter.formatToParts(date)) p[part.type] = part.value;
+
+    const day = `${p['day']}/${p['month']}`;
+    const time = `${p['hour']}:${p['minute']}`;
+
+    switch (format) {
+      case 'dd/MM/yyyy HH:mm': return `${day}/${p['year']} ${time}`;
+      case 'dd/MM/yyyy': return `${day}/${p['year']}`;
+      case 'dd/MM HH:mm': return `${day} ${time}`;
+      case 'HH:mm': return time;
+    }
+  }
+}

--- a/frontend/src/app/features/admin/admin-feedback/admin-feedback.component.html
+++ b/frontend/src/app/features/admin/admin-feedback/admin-feedback.component.html
@@ -23,7 +23,7 @@
           <div class="flex-1" style="min-width: 16rem">
             <p class="mt-0 mb-2" style="white-space: pre-wrap">{{ row.message }}</p>
             <div class="flex gap-2 flex-wrap text-sm" style="color: var(--p-text-muted-color)">
-              <span>{{ row.createdAt | date: 'dd/MM/yyyy HH:mm' }}</span>
+              <span>{{ row.createdAt | ilDate: 'dd/MM/yyyy HH:mm' }}</span>
               @if (row.contactInfo) {
                 <span>· {{ row.contactInfo }}</span>
               }

--- a/frontend/src/app/features/admin/admin-feedback/admin-feedback.component.ts
+++ b/frontend/src/app/features/admin/admin-feedback/admin-feedback.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, inject, signal } from '@angular/core';
-import { DatePipe } from '@angular/common';
+
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -11,6 +11,7 @@ import { EmptyStateComponent } from '../../../shared/ui/empty-state.component';
 import { PageHeaderComponent } from '../../../shared/ui/page-header.component';
 import { AdminSiteFeedback } from '../admin.models';
 import { AdminService } from '../admin.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 /**
  * ההודעות שנשלחו מרצועת "בהרצה". פותח על מה שלא טופל — רשימה שמצטברת בלי סימון
@@ -18,16 +19,13 @@ import { AdminService } from '../admin.service';
  */
 @Component({
   selector: 'app-admin-feedback',
-  imports: [
-    DatePipe,
-    FormsModule,
+  imports: [ FormsModule,
     ButtonModule,
     CardModule,
     TagModule,
     ToggleSwitchModule,
     EmptyStateComponent,
-    PageHeaderComponent
-  ],
+    PageHeaderComponent, IsraelDatePipe],
   templateUrl: './admin-feedback.component.html'
 })
 export class AdminFeedbackComponent implements OnInit {

--- a/frontend/src/app/features/admin/admin-teachers/admin-teachers.component.html
+++ b/frontend/src/app/features/admin/admin-teachers/admin-teachers.component.html
@@ -24,7 +24,7 @@
       </td>
       <td>{{ teacher.email }}</td>
       <td>{{ teacher.studentCount }}</td>
-      <td>{{ teacher.createdAt | date: 'dd/MM/yyyy' }}</td>
+      <td>{{ teacher.createdAt | ilDate: 'dd/MM/yyyy' }}</td>
       <td>
         <p-tag [value]="teacher.isPublic ? 'מוצגת' : 'לא מוצגת'" [severity]="teacher.isPublic ? 'success' : 'secondary'" />
       </td>

--- a/frontend/src/app/features/admin/admin-teachers/admin-teachers.component.ts
+++ b/frontend/src/app/features/admin/admin-teachers/admin-teachers.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -10,10 +10,11 @@ import { extractErrorMessage } from '../../../core/http/extract-error-message';
 import { getAvatarColor, getInitials } from '../../../shared/avatar/avatar.util';
 import { AdminService } from '../admin.service';
 import { AdminTeacher } from '../admin.models';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-admin-teachers',
-  imports: [DatePipe, ButtonModule, TableModule, TagModule, PageHeaderComponent, EmptyStateComponent],
+  imports: [ ButtonModule, TableModule, TagModule, PageHeaderComponent, EmptyStateComponent, IsraelDatePipe],
   templateUrl: './admin-teachers.component.html'
 })
 export class AdminTeachersComponent implements OnInit {

--- a/frontend/src/app/features/contact-requests/contact-requests.component.html
+++ b/frontend/src/app/features/contact-requests/contact-requests.component.html
@@ -31,7 +31,7 @@
           <div>
             <h3 class="m-0">{{ contact.fullName }}</h3>
             <span class="text-sm text-color-secondary">
-              {{ contact.createdAt | date: 'dd/MM/yyyy HH:mm' }}
+              {{ contact.createdAt | ilDate: 'dd/MM/yyyy HH:mm' }}
               @if (contact.subject) {
                 · {{ contact.subject }}
               }

--- a/frontend/src/app/features/contact-requests/contact-requests.component.ts
+++ b/frontend/src/app/features/contact-requests/contact-requests.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -19,21 +19,19 @@ import {
   ContactRequestStatus
 } from './contact-requests.models';
 import { ContactRequestsService } from './contact-requests.service';
+import { IsraelDatePipe } from '../../core/i18n/israel-date.pipe';
 
 /** תיבת הפניות שהגיעו מהספרייה הציבורית. */
 @Component({
   selector: 'app-contact-requests',
-  imports: [
-    FormsModule,
-    DatePipe,
+  imports: [ FormsModule,
     ButtonModule,
     CardModule,
     SelectButtonModule,
     TagModule,
     TooltipModule,
     EmptyStateComponent,
-    PageHeaderComponent
-  ],
+    PageHeaderComponent, IsraelDatePipe],
   templateUrl: './contact-requests.component.html'
 })
 export class ContactRequestsComponent implements OnInit {

--- a/frontend/src/app/features/dashboard/dashboard.component.html
+++ b/frontend/src/app/features/dashboard/dashboard.component.html
@@ -100,7 +100,7 @@
       @for (lesson of todayLessons(); track lesson.id) {
         <li class="flex justify-content-between align-items-center py-2">
           <div class="flex align-items-center gap-3">
-            <span class="text-color-secondary font-medium">{{ lesson.startTime | date: 'HH:mm' }}</span>
+            <span class="text-color-secondary font-medium">{{ lesson.startTime | ilDate: 'HH:mm' }}</span>
             <span>{{ lesson.studentName }}</span>
           </div>
           <p-tag [value]="statusLabel(lesson.status)" [severity]="statusSeverity(lesson.status)" />

--- a/frontend/src/app/features/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/dashboard/dashboard.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -15,20 +15,18 @@ import { ContactRequestsService } from '../contact-requests/contact-requests.ser
 import { PaymentsService } from '../payments/payments.service';
 import { StudentsService } from '../students/students.service';
 import { ProfileSetupService } from '../teacher/profile-setup/profile-setup.service';
+import { IsraelDatePipe } from '../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-dashboard',
-  imports: [
-    RouterLink,
-    DatePipe,
+  imports: [ RouterLink,
     ButtonModule,
     CardModule,
     TagModule,
     EmptyStateComponent,
     PageHeaderComponent,
     StatCardComponent,
-    SpotlightDirective
-  ],
+    SpotlightDirective, IsraelDatePipe],
   templateUrl: './dashboard.component.html'
 })
 export class DashboardComponent implements OnInit {

--- a/frontend/src/app/features/lessons/lessons-list/lessons-list.component.html
+++ b/frontend/src/app/features/lessons/lessons-list/lessons-list.component.html
@@ -344,7 +344,7 @@
   @if (selectedLesson(); as lesson) {
     <div class="flex flex-column gap-2">
       <div><strong>תלמיד:</strong> {{ lesson.studentName }}</div>
-      <div><strong>מועד:</strong> {{ lesson.startTime | date: 'dd/MM/yyyy HH:mm' }} – {{ lesson.endTime | date: 'HH:mm' }}</div>
+      <div><strong>מועד:</strong> {{ lesson.startTime | ilDate: 'dd/MM/yyyy HH:mm' }} – {{ lesson.endTime | ilDate: 'HH:mm' }}</div>
       <div><strong>סטטוס:</strong> <p-tag [value]="statusLabel(lesson.status)" [severity]="statusSeverity(lesson.status)" /></div>
       @if (lesson.seriesId) {
         <div><p-tag value="🔁 שיעור חוזר" severity="info" /></div>
@@ -389,9 +389,9 @@
     <div class="flex flex-column gap-2">
       <div><strong>תלמיד:</strong> {{ request.studentName }}</div>
       <div><strong>הורה מבקש:</strong> {{ request.parentName }}</div>
-      <div><strong>מועד נוכחי:</strong> {{ request.lessonStartTime | date: 'dd/MM/yyyy HH:mm' }} – {{ request.lessonEndTime | date: 'HH:mm' }}</div>
+      <div><strong>מועד נוכחי:</strong> {{ request.lessonStartTime | ilDate: 'dd/MM/yyyy HH:mm' }} – {{ request.lessonEndTime | ilDate: 'HH:mm' }}</div>
       @if (request.type === ChangeRequestType.Reschedule && request.proposedStartTime) {
-        <div><strong>מועד מוצע:</strong> {{ request.proposedStartTime | date: 'dd/MM/yyyy HH:mm' }} – {{ request.proposedEndTime | date: 'HH:mm' }}</div>
+        <div><strong>מועד מוצע:</strong> {{ request.proposedStartTime | ilDate: 'dd/MM/yyyy HH:mm' }} – {{ request.proposedEndTime | ilDate: 'HH:mm' }}</div>
       }
       @if (request.reason) {
         <div><strong>סיבה:</strong> {{ request.reason }}</div>

--- a/frontend/src/app/features/lessons/lessons-list/lessons-list.component.ts
+++ b/frontend/src/app/features/lessons/lessons-list/lessons-list.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe, formatDate } from '@angular/common';
+import { formatDate } from '@angular/common';
 import { Component, LOCALE_ID, OnInit, computed, inject, signal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AbstractControl, FormBuilder, FormsModule, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
@@ -38,12 +38,12 @@ import {
 import { LessonsService } from '../lessons.service';
 import { CalendarEventsService } from '../calendar-events.service';
 import { CalendarEventItem } from '../calendar-events.models';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-lessons-list',
-  imports: [ReactiveFormsModule,
+  imports: [ ReactiveFormsModule,
     FormsModule,
-    DatePipe,
     PrimeTemplate,
     ButtonModule,
     CheckboxModule,
@@ -55,7 +55,7 @@ import { CalendarEventItem } from '../calendar-events.models';
     SelectModule,
     TagModule,
     TextareaModule,
-    LessonCalendarComponent, PageHeaderComponent],
+    LessonCalendarComponent, PageHeaderComponent, IsraelDatePipe],
   templateUrl: './lessons-list.component.html'
 })
 export class LessonsListComponent implements OnInit {

--- a/frontend/src/app/features/messages/conversation.component.html
+++ b/frontend/src/app/features/messages/conversation.component.html
@@ -44,7 +44,7 @@
     @for (message of thread().messages; track message.id) {
       <article class="bubble" [class.is-mine]="message.senderRole === me()">
         <p class="bubble-body">{{ message.body }}</p>
-        <time class="bubble-time">{{ message.createdAt | date: 'dd/MM/yyyy HH:mm' }}</time>
+        <time class="bubble-time">{{ message.createdAt | ilDate: 'dd/MM/yyyy HH:mm' }}</time>
       </article>
     }
   </div>

--- a/frontend/src/app/features/messages/conversation.component.ts
+++ b/frontend/src/app/features/messages/conversation.component.ts
@@ -1,10 +1,11 @@
-import { DatePipe } from '@angular/common';
+
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { TextareaModule } from 'primeng/textarea';
 import { TooltipModule } from 'primeng/tooltip';
 import { MessageAuthor, ThreadDetail } from './messages.models';
+import { IsraelDatePipe } from '../../core/i18n/israel-date.pipe';
 
 /**
  * חלון השיחה: ההודעות לפי סדר, וחלון כתיבה בתחתית.
@@ -15,7 +16,7 @@ import { MessageAuthor, ThreadDetail } from './messages.models';
 @Component({
   selector: 'app-conversation',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe, FormsModule, ButtonModule, TextareaModule, TooltipModule],
+  imports: [ FormsModule, ButtonModule, TextareaModule, TooltipModule, IsraelDatePipe],
   templateUrl: './conversation.component.html',
   styleUrl: './messages.scss'
 })

--- a/frontend/src/app/features/messages/thread-list.component.html
+++ b/frontend/src/app/features/messages/thread-list.component.html
@@ -14,7 +14,7 @@
             }
             {{ title(thread) }}
           </span>
-          <span class="thread-row-time">{{ thread.lastMessageAt | date: 'dd/MM HH:mm' }}</span>
+          <span class="thread-row-time">{{ thread.lastMessageAt | ilDate: 'dd/MM HH:mm' }}</span>
         </span>
 
         @if (context(thread); as line) {

--- a/frontend/src/app/features/messages/thread-list.component.ts
+++ b/frontend/src/app/features/messages/thread-list.component.ts
@@ -1,6 +1,7 @@
-import { DatePipe } from '@angular/common';
+
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
 import { MessageAuthor, ThreadSummary } from './messages.models';
+import { IsraelDatePipe } from '../../core/i18n/israel-date.pipe';
 
 /**
  * רשימת השיחות. אותה רשימה משרתת את המורה ואת מי שמדבר איתה, ומה שמשתנה הוא רק
@@ -9,7 +10,7 @@ import { MessageAuthor, ThreadSummary } from './messages.models';
 @Component({
   selector: 'app-thread-list',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DatePipe],
+  imports: [ IsraelDatePipe],
   templateUrl: './thread-list.component.html',
   styleUrl: './messages.scss'
 })

--- a/frontend/src/app/features/notifications/notifications-bell/notifications-bell.component.html
+++ b/frontend/src/app/features/notifications/notifications-bell/notifications-bell.component.html
@@ -30,7 +30,7 @@
             <div class="flex-1">
               <div class="font-medium">{{ n.title }}</div>
               <div class="text-sm text-color-secondary">{{ n.message }}</div>
-              <div class="text-xs text-color-secondary mt-1">{{ n.createdAt | date: 'dd/MM/yyyy HH:mm' }}</div>
+              <div class="text-xs text-color-secondary mt-1">{{ n.createdAt | ilDate: 'dd/MM/yyyy HH:mm' }}</div>
             </div>
           </li>
         }

--- a/frontend/src/app/features/notifications/notifications-bell/notifications-bell.component.ts
+++ b/frontend/src/app/features/notifications/notifications-bell/notifications-bell.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, DestroyRef, OnInit, inject, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
@@ -9,10 +9,11 @@ import { timer } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { AppNotification, NotificationType, notificationIcon } from '../notifications.models';
 import { NotificationsService } from '../notifications.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-notifications-bell',
-  imports: [DatePipe, ButtonModule, PopoverModule, EmptyStateComponent],
+  imports: [ ButtonModule, PopoverModule, EmptyStateComponent, IsraelDatePipe],
   templateUrl: './notifications-bell.component.html'
 })
 export class NotificationsBellComponent implements OnInit {

--- a/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.html
+++ b/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.html
@@ -19,7 +19,7 @@
       icon="pi-calendar"
       tone="info"
       link="/parent/lessons"
-      [value]="nextLesson() ? (nextLesson()!.startTime | date: 'dd/MM HH:mm') : (lessons() === null ? null : '—')"
+      [value]="nextLesson() ? (nextLesson()!.startTime | ilDate: 'dd/MM HH:mm') : (lessons() === null ? null : '—')"
       [hint]="nextLesson() ? nextLesson()!.studentName : (lessons() === null ? null : 'אין שיעורים קרובים')" />
   </div>
 
@@ -47,7 +47,7 @@
       @for (lesson of upcomingLessons(); track lesson.id) {
         <li class="flex justify-content-between align-items-center py-2">
           <div class="flex align-items-center gap-3">
-            <span class="text-color-secondary">{{ lesson.startTime | date: 'dd/MM HH:mm' }}</span>
+            <span class="text-color-secondary">{{ lesson.startTime | ilDate: 'dd/MM HH:mm' }}</span>
             <span>{{ lesson.studentName }}</span>
           </div>
           <p-tag [value]="statusLabel(lesson.status)" [severity]="statusSeverity(lesson.status)" />

--- a/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.ts
+++ b/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CardModule } from 'primeng/card';
 import { TagModule } from 'primeng/tag';
@@ -8,10 +8,11 @@ import { LESSON_STATUS_LABELS, LESSON_STATUS_SEVERITY, Lesson, LessonStatus } fr
 import { OpenCharge } from '../../payments/payments.models';
 import { MyChild } from '../parent-portal.models';
 import { ParentPortalService } from '../parent-portal.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-parent-dashboard',
-  imports: [DatePipe, CardModule, TagModule, PageHeaderComponent, StatCardComponent],
+  imports: [ CardModule, TagModule, PageHeaderComponent, StatCardComponent, IsraelDatePipe],
   templateUrl: './parent-dashboard.component.html'
 })
 export class ParentDashboardComponent implements OnInit {

--- a/frontend/src/app/features/parent-portal/parent-lessons/parent-lessons.component.html
+++ b/frontend/src/app/features/parent-portal/parent-lessons/parent-lessons.component.html
@@ -151,7 +151,7 @@
   @if (selectedLesson(); as lesson) {
     <div class="flex flex-column gap-2">
       <div><strong>ילד/ה:</strong> {{ lesson.studentName }}</div>
-      <div><strong>מועד:</strong> {{ lesson.startTime | date: 'dd/MM/yyyy HH:mm' }} – {{ lesson.endTime | date: 'HH:mm' }}</div>
+      <div><strong>מועד:</strong> {{ lesson.startTime | ilDate: 'dd/MM/yyyy HH:mm' }} – {{ lesson.endTime | ilDate: 'HH:mm' }}</div>
       <div><strong>סטטוס:</strong> <p-tag [value]="statusLabel(lesson.status)" [severity]="statusSeverity(lesson.status)" /></div>
       @if (lesson.homework) {
         <div><strong>שיעורי בית:</strong> {{ lesson.homework }}</div>

--- a/frontend/src/app/features/parent-portal/parent-lessons/parent-lessons.component.ts
+++ b/frontend/src/app/features/parent-portal/parent-lessons/parent-lessons.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MessageService } from 'primeng/api';
@@ -18,19 +18,19 @@ import { lessonToCalendarEvent } from '../../lessons/lesson-calendar.util';
 import { LESSON_STATUS_LABELS, LESSON_STATUS_SEVERITY, ChangeRequestType, Lesson, LessonStatus } from '../../lessons/lessons.models';
 import { MyChild } from '../parent-portal.models';
 import { ParentPortalService } from '../parent-portal.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-parent-lessons',
-  imports: [ReactiveFormsModule,
+  imports: [ ReactiveFormsModule,
     FormsModule,
-    DatePipe,
     ButtonModule,
     DatePickerModule,
     DialogModule,
     InputTextModule,
     SelectModule,
     TagModule,
-    LessonCalendarComponent, PageHeaderComponent],
+    LessonCalendarComponent, PageHeaderComponent, IsraelDatePipe],
   templateUrl: './parent-lessons.component.html'
 })
 export class ParentLessonsComponent implements OnInit {

--- a/frontend/src/app/features/parent-portal/parent-notes/parent-notes.component.html
+++ b/frontend/src/app/features/parent-portal/parent-notes/parent-notes.component.html
@@ -46,7 +46,7 @@
             </span>
             <span class="font-bold">{{ note.studentName }}</span>
           </div>
-          <span class="text-sm text-color-secondary">{{ note.createdAt | date: 'dd/MM/yyyy HH:mm' }}</span>
+          <span class="text-sm text-color-secondary">{{ note.createdAt | ilDate: 'dd/MM/yyyy HH:mm' }}</span>
         </div>
         <p class="m-0" style="white-space: pre-wrap">{{ note.content }}</p>
         <div class="mt-2">

--- a/frontend/src/app/features/parent-portal/parent-notes/parent-notes.component.ts
+++ b/frontend/src/app/features/parent-portal/parent-notes/parent-notes.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
@@ -11,10 +11,11 @@ import { PageHeaderComponent } from '../../../shared/ui/page-header.component';
 import { getAvatarColor, getInitials } from '../../../shared/avatar/avatar.util';
 import { MyChild, ParentNote } from '../parent-portal.models';
 import { ParentPortalService } from '../parent-portal.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-parent-notes',
-  imports: [FormsModule, DatePipe, ButtonModule, CardModule, SelectModule, SkeletonModule, PageHeaderComponent, EmptyStateComponent],
+  imports: [ FormsModule, ButtonModule, CardModule, SelectModule, SkeletonModule, PageHeaderComponent, EmptyStateComponent, IsraelDatePipe],
   templateUrl: './parent-notes.component.html'
 })
 export class ParentNotesComponent implements OnInit {

--- a/frontend/src/app/features/parent-portal/parent-payments/parent-payments.component.html
+++ b/frontend/src/app/features/parent-portal/parent-payments/parent-payments.component.html
@@ -22,7 +22,7 @@
         <ng-template pTemplate="body" let-charge>
           <tr>
             <td>{{ charge.studentName }}</td>
-            <td>{{ charge.lessonStartTime | date: 'dd/MM/yyyy' }}</td>
+            <td>{{ charge.lessonStartTime | ilDate: 'dd/MM/yyyy' }}</td>
             <td>{{ charge.amount }} ₪</td>
           </tr>
         </ng-template>
@@ -47,7 +47,7 @@
         <ng-template pTemplate="body" let-payment>
           <tr>
             <td>{{ payment.amount }} ₪</td>
-            <td>{{ payment.paidDate | date: 'dd/MM/yyyy' }}</td>
+            <td>{{ payment.paidDate | ilDate: 'dd/MM/yyyy' }}</td>
             <td>{{ payment.method || '—' }}</td>
             <td>{{ payment.lessonCount }}</td>
           </tr>

--- a/frontend/src/app/features/parent-portal/parent-payments/parent-payments.component.ts
+++ b/frontend/src/app/features/parent-portal/parent-payments/parent-payments.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { TableModule } from 'primeng/table';
 import { TabsModule } from 'primeng/tabs';
@@ -6,10 +6,11 @@ import { TagModule } from 'primeng/tag';
 import { PageHeaderComponent } from '../../../shared/ui/page-header.component';
 import { OpenCharge, Payment } from '../../payments/payments.models';
 import { ParentPortalService } from '../parent-portal.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-parent-payments',
-  imports: [DatePipe, TableModule, TabsModule, TagModule, PageHeaderComponent],
+  imports: [ TableModule, TabsModule, TagModule, PageHeaderComponent, IsraelDatePipe],
   templateUrl: './parent-payments.component.html'
 })
 export class ParentPaymentsComponent implements OnInit {

--- a/frontend/src/app/features/payments/payments-list/payments-list.component.html
+++ b/frontend/src/app/features/payments/payments-list/payments-list.component.html
@@ -57,7 +57,7 @@
                   {{ charge.studentName }}
                 </div>
               </td>
-              <td>{{ charge.lessonStartTime | date: 'dd/MM/yyyy' }}</td>
+              <td>{{ charge.lessonStartTime | ilDate: 'dd/MM/yyyy' }}</td>
               <td>{{ charge.amount }} ₪</td>
             </tr>
           </ng-template>
@@ -144,7 +144,7 @@
               </div>
             </td>
             <td>{{ payment.amount }} ₪</td>
-            <td>{{ payment.paidDate | date: 'dd/MM/yyyy' }}</td>
+            <td>{{ payment.paidDate | ilDate: 'dd/MM/yyyy' }}</td>
             <td>{{ payment.method || '—' }}</td>
             <td>{{ payment.lessonCount }}</td>
             <td>

--- a/frontend/src/app/features/payments/payments-list/payments-list.component.ts
+++ b/frontend/src/app/features/payments/payments-list/payments-list.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -19,12 +19,12 @@ import { Parent } from '../../parents/parents.models';
 import { ParentsService } from '../../parents/parents.service';
 import { OpenCharge, Payment } from '../payments.models';
 import { PaymentsService } from '../payments.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-payments-list',
-  imports: [ReactiveFormsModule,
+  imports: [ ReactiveFormsModule,
     FormsModule,
-    DatePipe,
     ButtonModule,
     CheckboxModule,
     DatePickerModule,
@@ -32,7 +32,7 @@ import { PaymentsService } from '../payments.service';
     SelectModule,
     TableModule,
     TabsModule,
-    TagModule, PageHeaderComponent, EmptyStateComponent],
+    TagModule, PageHeaderComponent, EmptyStateComponent, IsraelDatePipe],
   templateUrl: './payments-list.component.html'
 })
 export class PaymentsListComponent implements OnInit {

--- a/frontend/src/app/features/resources/resource-list.component.ts
+++ b/frontend/src/app/features/resources/resource-list.component.ts
@@ -1,8 +1,9 @@
-import { DatePipe } from '@angular/common';
+
 import { ChangeDetectionStrategy, Component, input, output } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
 import { TooltipModule } from 'primeng/tooltip';
 import { PortalResource, StudentResource, resourceColor, resourceHost, resourceIcon, resourceKindLabel } from './resources.models';
+import { IsraelDatePipe } from '../../core/i18n/israel-date.pipe';
 
 /**
  * רשימת חומרי לימוד — משותפת למסך המורה ולשני הפורטלים, כדי שחומר ייראה אותו דבר
@@ -11,7 +12,7 @@ import { PortalResource, StudentResource, resourceColor, resourceHost, resourceI
  */
 @Component({
   selector: 'app-resource-list',
-  imports: [DatePipe, ButtonModule, TooltipModule],
+  imports: [ ButtonModule, TooltipModule, IsraelDatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ul class="resource-list">
@@ -27,7 +28,7 @@ import { PortalResource, StudentResource, resourceColor, resourceHost, resourceI
               @if (showStudentName()) {
                 · {{ studentNameOf(resource) }}
               }
-              · {{ resource.createdAt | date: 'dd/MM/yyyy' }}
+              · {{ resource.createdAt | ilDate: 'dd/MM/yyyy' }}
             </span>
             @if (resource.description) {
               <p class="resource-description">{{ resource.description }}</p>

--- a/frontend/src/app/features/student-portal/student-dashboard/student-dashboard.component.html
+++ b/frontend/src/app/features/student-portal/student-dashboard/student-dashboard.component.html
@@ -8,7 +8,7 @@
       icon="pi-calendar"
       tone="primary"
       link="/student/lessons"
-      [value]="nextLesson() ? (nextLesson()!.startTime | date: 'dd/MM HH:mm') : (lessons() === null ? null : '—')"
+      [value]="nextLesson() ? (nextLesson()!.startTime | ilDate: 'dd/MM HH:mm') : (lessons() === null ? null : '—')"
       [hint]="nextLesson() ? null : (lessons() === null ? null : 'אין שיעורים קרובים')" />
   </div>
 
@@ -37,7 +37,7 @@
     <ul class="parent-list">
       @for (lesson of upcomingLessons(); track lesson.id) {
         <li class="flex justify-content-between align-items-center py-2">
-          <span class="text-color-secondary">{{ lesson.startTime | date: 'dd/MM HH:mm' }}</span>
+          <span class="text-color-secondary">{{ lesson.startTime | ilDate: 'dd/MM HH:mm' }}</span>
           <p-tag [value]="statusLabel(lesson.status)" [severity]="statusSeverity(lesson.status)" />
         </li>
       }

--- a/frontend/src/app/features/student-portal/student-dashboard/student-dashboard.component.ts
+++ b/frontend/src/app/features/student-portal/student-dashboard/student-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { CardModule } from 'primeng/card';
 import { TagModule } from 'primeng/tag';
@@ -7,10 +7,11 @@ import { PageHeaderComponent } from '../../../shared/ui/page-header.component';
 import { LESSON_STATUS_LABELS, LESSON_STATUS_SEVERITY, LessonStatus } from '../../lessons/lessons.models';
 import { StudentLesson } from '../student-portal.models';
 import { StudentPortalService } from '../student-portal.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-student-dashboard',
-  imports: [DatePipe, CardModule, TagModule, PageHeaderComponent, StatCardComponent],
+  imports: [ CardModule, TagModule, PageHeaderComponent, StatCardComponent, IsraelDatePipe],
   templateUrl: './student-dashboard.component.html'
 })
 export class StudentDashboardComponent implements OnInit {

--- a/frontend/src/app/features/student-portal/student-lessons/student-lessons.component.html
+++ b/frontend/src/app/features/student-portal/student-lessons/student-lessons.component.html
@@ -9,7 +9,7 @@
 <p-dialog header="פרטי שיעור" [(visible)]="showLessonDetailDialog" [modal]="true" [style]="{ width: '380px' }">
   @if (selectedLesson(); as lesson) {
     <div class="flex flex-column gap-2">
-      <div><strong>מועד:</strong> {{ lesson.startTime | date: 'dd/MM/yyyy HH:mm' }} – {{ lesson.endTime | date: 'HH:mm' }}</div>
+      <div><strong>מועד:</strong> {{ lesson.startTime | ilDate: 'dd/MM/yyyy HH:mm' }} – {{ lesson.endTime | ilDate: 'HH:mm' }}</div>
       <div><strong>סטטוס:</strong> <p-tag [value]="statusLabel(lesson.status)" [severity]="statusSeverity(lesson.status)" /></div>
       @if (lesson.homework) {
         <div><strong>שיעורי בית:</strong> {{ lesson.homework }}</div>

--- a/frontend/src/app/features/student-portal/student-lessons/student-lessons.component.ts
+++ b/frontend/src/app/features/student-portal/student-lessons/student-lessons.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { EventInput } from 'fullcalendar';
@@ -17,20 +17,18 @@ import { LessonCalendarComponent } from '../../../shared/calendar/lesson-calenda
 import { LESSON_STATUS_CLASS, LESSON_STATUS_LABELS, LESSON_STATUS_SEVERITY, LessonStatus } from '../../lessons/lessons.models';
 import { StudentLesson } from '../student-portal.models';
 import { StudentPortalService } from '../student-portal.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-student-lessons',
-  imports: [
-    DatePipe,
-    ReactiveFormsModule,
+  imports: [ ReactiveFormsModule,
     ButtonModule,
     DatePickerModule,
     DialogModule,
     TagModule,
     TextareaModule,
     LessonCalendarComponent,
-    PageHeaderComponent
-  ],
+    PageHeaderComponent, IsraelDatePipe],
   templateUrl: './student-lessons.component.html'
 })
 export class StudentLessonsComponent implements OnInit {

--- a/frontend/src/app/features/student-portal/student-notes/student-notes.component.html
+++ b/frontend/src/app/features/student-portal/student-notes/student-notes.component.html
@@ -21,7 +21,7 @@
       <li class="py-3 note-item">
         <p class="m-0" style="white-space: pre-wrap">{{ note.content }}</p>
         <div class="mt-2 flex align-items-center justify-content-between gap-2 flex-wrap">
-          <span class="text-sm text-color-secondary">{{ note.createdAt | date: 'dd/MM/yyyy HH:mm' }}</span>
+          <span class="text-sm text-color-secondary">{{ note.createdAt | ilDate: 'dd/MM/yyyy HH:mm' }}</span>
           <p-button label="השב" icon="pi pi-reply" [text]="true" size="small" (onClick)="reply(note)" />
         </div>
       </li>

--- a/frontend/src/app/features/student-portal/student-notes/student-notes.component.ts
+++ b/frontend/src/app/features/student-portal/student-notes/student-notes.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
@@ -7,10 +7,11 @@ import { EmptyStateComponent } from '../../../shared/ui/empty-state.component';
 import { PageHeaderComponent } from '../../../shared/ui/page-header.component';
 import { StudentNote } from '../student-portal.models';
 import { StudentPortalService } from '../student-portal.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-student-notes',
-  imports: [DatePipe, ButtonModule, SkeletonModule, PageHeaderComponent, EmptyStateComponent],
+  imports: [ ButtonModule, SkeletonModule, PageHeaderComponent, EmptyStateComponent, IsraelDatePipe],
   templateUrl: './student-notes.component.html'
 })
 export class StudentNotesComponent implements OnInit {

--- a/frontend/src/app/features/students/student-detail/student-detail.component.html
+++ b/frontend/src/app/features/students/student-detail/student-detail.component.html
@@ -31,7 +31,7 @@
     <div class="mb-4">
       <div class="mb-1"><span class="text-color-secondary">כיתה: </span>{{ student()!.gradeLevel || '—' }}</div>
       <div class="mb-1">
-        <span class="text-color-secondary">תאריך לידה: </span>{{ (student()!.birthDate | date: 'dd/MM/yyyy') || '—' }}
+        <span class="text-color-secondary">תאריך לידה: </span>{{ (student()!.birthDate | ilDate: 'dd/MM/yyyy') || '—' }}
       </div>
       <div class="mb-1">
         <span class="text-color-secondary">מחיר לשיעור: </span>{{ student()!.defaultPricePerLesson != null ? student()!.defaultPricePerLesson + ' ₪' : 'ברירת מחדל של המורה' }}
@@ -116,7 +116,7 @@
             <div class="flex gap-2 mt-2 align-items-center">
               <p-tag [value]="note.visibleToStudent ? 'גלוי לתלמיד' : 'מוסתר מתלמיד'" [severity]="note.visibleToStudent ? 'success' : 'secondary'" />
               <p-tag [value]="note.visibleToParent ? 'גלוי להורה' : 'מוסתר מהורה'" [severity]="note.visibleToParent ? 'success' : 'secondary'" />
-              <span class="text-sm text-color-secondary">{{ note.createdAt | date: 'dd/MM/yyyy HH:mm' }}</span>
+              <span class="text-sm text-color-secondary">{{ note.createdAt | ilDate: 'dd/MM/yyyy HH:mm' }}</span>
             </div>
           </li>
         }

--- a/frontend/src/app/features/students/student-detail/student-detail.component.ts
+++ b/frontend/src/app/features/students/student-detail/student-detail.component.ts
@@ -1,4 +1,4 @@
-import { DatePipe } from '@angular/common';
+
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
@@ -31,14 +31,13 @@ import { StudentResource } from '../../resources/resources.models';
 import { ResourcesService } from '../../resources/resources.service';
 import { ParentSummary, StudentDetail } from '../students.models';
 import { StudentsService } from '../students.service';
+import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-student-detail',
-  imports: [
-    ReactiveFormsModule,
+  imports: [ ReactiveFormsModule,
     FormsModule,
     RouterLink,
-    DatePipe,
     ButtonModule,
     CardModule,
     CheckboxModule,
@@ -51,8 +50,7 @@ import { StudentsService } from '../students.service';
     TextareaModule,
     TooltipModule,
     EmptyStateComponent,
-    ResourceListComponent
-  ],
+    ResourceListComponent, IsraelDatePipe],
   templateUrl: './student-detail.component.html'
 })
 export class StudentDetailComponent implements OnInit {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -437,6 +437,37 @@ a:hover {
   .library-content {
     padding-inline: 0.9rem;
   }
+
+  /* בטלפון הסרגל העליון הוא לוגו ועוד שורת אייקונים, והם רחבים יחד ממסך של 390px.
+     ילד של flex לא מתכווץ מתחת לתוכנו כל עוד min-width הוא auto — ולכן במקום
+     להצטמצם, הסרגל דחף את העמוד כולו ל-485px וכל המסכים נגללו הצידה. */
+  .app-shell-topbar .p-menubar,
+  .app-shell-topbar .p-menubar-start,
+  .app-shell-topbar .p-menubar-end,
+  .app-shell-topbar .p-menubar-root-list {
+    min-width: 0;
+  }
+  .app-shell-topbar .p-menubar-end {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    row-gap: 0.25rem;
+  }
+  /* חמישה אייקונים בשורה אחת: מצמצמים ריווח ופנימיים כדי שייכנסו לרוחב הטלפון. */
+  .app-shell-topbar .p-menubar-end .p-button.p-button-icon-only,
+  .app-shell-topbar .p-menubar-end .user-menu-trigger {
+    padding: 0.35rem;
+  }
+  .app-shell-topbar .p-menubar-end > .flex {
+    gap: 0.15rem;
+  }
+  /* שם המותג לא מתקצר: "תלמידון" שנחתך ל"תלמיד" הוא מותג שבור, לא חיסכון במקום. */
+  .app-shell-topbar .brand {
+    flex: none;
+  }
+  /* רשת ביטחון: אף פיקסל חורג בסרגל לא יגרום לכל העמוד להיגלל הצידה. */
+  .app-shell {
+    overflow-x: clip;
+  }
 }
 
 /* ------------------------------------------------- כותרת מסך (page-header) ---- */


### PR DESCRIPTION
Two bugs found by using the app in a browser rather than reading the code.

## Lesson times followed the device's timezone

The same lesson, same parent account:

| Device timezone | Time shown |
|---|---|
| Asia/Jerusalem | 18:00 |
| Europe/London | 16:00 |
| America/New_York | 11:00 |

Angular's `DatePipe` formats in the browser's zone, while the server is deliberately pinned to `Asia/Jerusalem` (`AppTimeZone`). A lesson time is a local fact — a parent whose phone is set to another zone was shown the wrong hour and could miss the lesson.

An `ilDate` pipe now formats through `Intl.DateTimeFormat` with an explicit `timeZone`, across all 30 call sites. `Intl` and not a fixed `+0300` offset: an offset breaks twice a year at the DST change, which is the trap the server already avoids in `AppTimeZone.ToUtc`.

After the fix all three timezones read **18:00**.

## The teacher shell overflowed on a phone

485px of page on a 390px screen, so every teacher screen scrolled sideways. The topbar is the brand plus five icons, and flex children do not shrink below their content while `min-width` is `auto`. They shrink now, the icon row is tighter, and the shell clips as a last resort.

The parent and student portals were never affected — this was the teacher shell only.

## Verification

- Real browser at **390px and 360px**: no overflow on `/app/dashboard`, `/app/lessons`, `/app/students`, `/app/payments`.
- The brand still reads **תלמידון** in full — an earlier attempt truncated it to "תלמיד", which is why the check is in here.
- Same lesson reads 18:00 in all three timezones.
- **148 tests pass**; the front end builds with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L)_