### PR TITLE
Put "request a lesson" on the parent's home screen

### DIFF
--- a/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.html
+++ b/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.html
@@ -1,4 +1,10 @@
-<app-page-header title="ראשי" icon="pi-home" />
+<app-page-header title="ראשי" icon="pi-home">
+  <p-button
+    label="בקש שיעור חדש"
+    icon="pi pi-plus"
+    routerLink="/parent/lessons"
+    [queryParams]="{ request: 1 }" />
+</app-page-header>
 
 <div class="grid">
   <div class="col-12 md:col-4">

--- a/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.ts
+++ b/frontend/src/app/features/parent-portal/parent-dashboard/parent-dashboard.component.ts
@@ -1,5 +1,7 @@
 
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
 import { TagModule } from 'primeng/tag';
 import { StatCardComponent } from '../../../shared/ui/stat-card.component';
@@ -12,7 +14,7 @@ import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
 @Component({
   selector: 'app-parent-dashboard',
-  imports: [ CardModule, TagModule, PageHeaderComponent, StatCardComponent, IsraelDatePipe],
+  imports: [RouterLink, ButtonModule, CardModule, TagModule, PageHeaderComponent, StatCardComponent, IsraelDatePipe],
   templateUrl: './parent-dashboard.component.html'
 })
 export class ParentDashboardComponent implements OnInit {

--- a/frontend/src/app/features/parent-portal/parent-lessons/parent-lessons.component.ts
+++ b/frontend/src/app/features/parent-portal/parent-lessons/parent-lessons.component.ts
@@ -1,6 +1,7 @@
 
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { DatePickerModule } from 'primeng/datepicker';
@@ -36,6 +37,7 @@ import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 export class ParentLessonsComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
   private readonly portalService = inject(ParentPortalService);
+  private readonly route = inject(ActivatedRoute);
   private readonly messageService = inject(MessageService);
 
   protected readonly LessonStatus = LessonStatus;
@@ -80,7 +82,12 @@ export class ParentLessonsComponent implements OnInit {
   });
 
   ngOnInit(): void {
-    this.portalService.myChildren().subscribe(children => this.children.set(children));
+    this.portalService.myChildren().subscribe(children => {
+      this.children.set(children);
+      // הגעה מ"בקש שיעור" שבמסך הבית. נפתח רק אחרי שהילדים נטענו, כי הטופס
+      // נפתח על הילד/ה שנבחר/ה — לפני כן הוא היה נפתח ריק.
+      if (this.route.snapshot.queryParamMap.get('request') === '1') this.openRequestDialog();
+    });
     this.load();
   }
 


### PR DESCRIPTION
Asking for a lesson is the one thing a parent opens the portal to do, and the home screen had no way to start it — the button lived on the lessons screen, so it took a navigation first. Measured while using the portal as a parent: **zero** request entry points on `/parent/dashboard`.

The button now sits in the home screen's header and carries `request=1` through to the lessons screen, which opens the dialog that already exists. One entry point, one dialog, no duplicated form.

The dialog opens only after the children have loaded — it pre-selects the child, and opening it earlier left that field empty.

### Verification

Driven in a real browser at 390px, logged in as a parent:

- Request button on the home screen: **found**
- After **one tap**: `/parent/lessons?request=1` with the dialog **open**
- Dialog reads: `בקשת שיעור חדש · ילד/ה · התחלה מבוקשת · סיום מבוקש · הערה · שלח בקשה`
- No page errors, no horizontal scroll
- **165 tests pass**; front end builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L)_