### PR TITLE
Open the calendar as an agenda on a phone

### DIFF
--- a/frontend/src/app/features/lessons/lessons-list/lessons-list.component.html
+++ b/frontend/src/app/features/lessons/lessons-list/lessons-list.component.html
@@ -40,7 +40,19 @@
 </div>
 
 @if (availabilitySummary().length > 0) {
-  <div class="availability-summary flex align-items-center gap-2 flex-wrap mb-3 text-sm">
+  <!-- בטלפון שעות הזמינות מקופלות מאחורי מתג: זה מידע עזר, והוא דחף את היומן
+       עצמו מתחת לקיפול. במחשב אין מתג והשורה פתוחה תמיד. -->
+  <button
+    type="button"
+    class="availability-toggle"
+    [attr.aria-expanded]="showAvailability()"
+    (click)="showAvailability.set(!showAvailability())">
+    <i class="pi" [class.pi-chevron-down]="!showAvailability()" [class.pi-chevron-up]="showAvailability()"></i>
+    שעות זמינות
+  </button>
+  <div
+    class="availability-summary align-items-center gap-2 flex-wrap mb-3 text-sm"
+    [class.availability-open]="showAvailability()">
     <i class="pi pi-clock text-color-secondary"></i>
     <span class="text-color-secondary">שעות זמינות:</span>
     @for (slot of availabilitySummary(); track slot) {

--- a/frontend/src/app/features/lessons/lessons-list/lessons-list.component.ts
+++ b/frontend/src/app/features/lessons/lessons-list/lessons-list.component.ts
@@ -124,6 +124,9 @@ export class LessonsListComponent implements OnInit {
   protected readonly changeRequestsLoading = signal(true);
 
   /** סינון היומן לפי תלמיד (null = כל התלמידים). */
+  /** פתיחת שעות הזמינות בטלפון. במחשב השורה פתוחה תמיד ב-CSS. */
+  protected readonly showAvailability = signal(false);
+
   protected readonly studentFilter = signal<string | null>(null);
 
   protected readonly calendarEvents = computed(() => {

--- a/frontend/src/app/shared/calendar/lesson-calendar.component.ts
+++ b/frontend/src/app/shared/calendar/lesson-calendar.component.ts
@@ -1,6 +1,7 @@
-import { Component, computed, input, output } from '@angular/core';
+import { Component, DestroyRef, computed, inject, input, output, signal } from '@angular/core';
 import { CalendarOptions, EventClickInfo, EventDropInfo, EventInput, EventResizeDoneInfo } from 'fullcalendar';
 import dayGridPlugin from 'fullcalendar/daygrid';
+import listPlugin from 'fullcalendar/list';
 import interactionPlugin from 'fullcalendar/interaction';
 import heLocale from 'fullcalendar/locales/he';
 import classicTheme from 'fullcalendar/themes/classic';
@@ -29,6 +30,8 @@ function buildDayHeader(date: Date, isToday: boolean): HTMLElement {
   return wrapper;
 }
 
+const NARROW = '(max-width: 640px)';
+
 /** עטיפה משותפת סביב FullCalendar — RTL/עברית, צביעה לפי סטטוס וטיפול בלחיצות. משמשת את יומני המורה/הורה/תלמיד. */
 @Component({
   selector: 'app-lesson-calendar',
@@ -36,6 +39,24 @@ function buildDayHeader(date: Date, isToday: boolean): HTMLElement {
   template: `<full-calendar [options]="calendarOptions()" />`
 })
 export class LessonCalendarComponent {
+  /**
+   * בטלפון היומן נפתח כסדר יום ולא כרשת שבוע: שבע עמודות ברוחב 45 פיקסל אינן
+   * קריאות, והרשת נפתחת על שעות ריקות בזמן שכל השיעורים אחר הצהריים. סיגנל ולא
+   * קריאה חד-פעמית ל-window, כדי שסיבוב המכשיר יעדכן את התצוגה.
+   */
+  protected readonly isNarrow = signal(
+    typeof window !== 'undefined' && window.matchMedia(NARROW).matches
+  );
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      const mq = window.matchMedia(NARROW);
+      const onChange = (e: MediaQueryListEvent) => this.isNarrow.set(e.matches);
+      mq.addEventListener('change', onChange);
+      inject(DestroyRef).onDestroy(() => mq.removeEventListener('change', onChange));
+    }
+  }
+
   readonly events = input<EventInput[]>([]);
   readonly selectable = input(false);
   /**
@@ -59,15 +80,17 @@ export class LessonCalendarComponent {
   readonly eventResized = output<CalendarEventDrop>();
 
   protected readonly calendarOptions = computed<CalendarOptions>(() => ({
-    plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin, classicTheme],
+    plugins: [dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin, classicTheme],
     locale: heLocale,
     direction: 'rtl',
-    initialView: this.initialView(),
-    headerToolbar: { start: 'prev,next today', center: 'title', end: 'dayGridMonth,timeGridWeek' },
+    initialView: this.isNarrow() ? 'listWeek' : this.initialView(),
+    headerToolbar: this.isNarrow()
+      ? { start: 'prev,next today', center: 'title', end: 'listWeek,dayGridMonth' }
+      : { start: 'prev,next today', center: 'title', end: 'dayGridMonth,timeGridWeek' },
     // גובה חסום עם גלילה פנימית, ולא 'auto': כך היומן לא משתלט על העמוד בשעות
     // הריקות, ו-scrollTime באמת עושה משהו. כל השעות נשארות נגישות בגלילה, ולכן
     // אין סכנה ששיעור מוקדם או מאוחר "ייעלם" (מה שהיה קורה בקיצור טווח השעות).
-    height: '68vh',
+    height: this.isNarrow() ? 'auto' : '68vh',
     firstDay: 0,
     // הדגשת היום הנוכחי — דרך המחלקות האלה ולא בסלקטור CSS, כי v7 מגבב את שמות
     // המחלקות הפנימיות שלו ואין וו יציב לתא של היום

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -790,6 +790,39 @@ full-calendar [class*="lesson-cal-"] .fc-event-title {
     display: none;
   }
 }
+
+/* התצוגה של שורת הזמינות מנוהלת כאן ולא במחלקת העזר ‎flex‎ של PrimeFlex: היא
+   מוגדרת עם ‎!important‎, ולכן קיפול השורה בטלפון לא היה תופס מולה. */
+.availability-summary {
+  display: flex;
+}
+
+/* מתג שעות הזמינות — קיים בטלפון בלבד. */
+.availability-toggle {
+  display: none;
+}
+@media (max-width: 640px) {
+  .availability-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-bottom: 0.75rem;
+    padding: 0.35rem 0.75rem;
+    border: 1px solid var(--p-content-border-color);
+    border-radius: var(--p-border-radius-md);
+    background: transparent;
+    color: var(--p-text-muted-color);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+  .availability-summary {
+    display: none;
+  }
+  .availability-summary.availability-open {
+    display: flex;
+  }
+}
 .legend-dot {
   display: inline-block;
   width: 10px;

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -781,6 +781,15 @@ full-calendar [class*="lesson-cal-"] .fc-event-title {
   font-size: 0.85rem;
   color: var(--p-text-muted-color);
 }
+
+/* בטלפון היומן הוא סדר יום, והמקרא מסביר צבעים של רשת שבוע: שש שורות שגזלו שליש
+   מסך לפני שהשיעור הראשון בכלל נראה. חייב לשבת אחרי ההגדרה הבסיסית — קודם הוא ישב
+   בבלוק של השלד, מוקדם יותר בקובץ, ו-display: flex שלמטה גבר עליו. */
+@media (max-width: 640px) {
+  .calendar-legend {
+    display: none;
+  }
+}
 .legend-dot {
   display: inline-block;
   width: 10px;


### PR DESCRIPTION
A seven-column week grid at ~45px per column is not readable on a phone, and it opened on 08:00 while every lesson is in the afternoon — the teacher saw an empty grid and had to scroll inside it.

On a narrow screen (≤640px) the calendar now opens as an agenda: day, time, student name.

**The legend goes with it.** It explains the colours of a week grid, and six rows of it were taking a third of the screen before the first lesson appeared. Worth noting for review: the rule had to go *after* the base `.calendar-legend` definition — placed in the shell's media block earlier in the file, the later `display: flex` overrode it and the legend stayed visible.

**Adding a lesson or an event still works** — the point raised when this was chosen. An agenda has no slots to drag-select, but both buttons above the calendar open their dialogs, and month view is one tap away.

A signal fed by `matchMedia`, not a one-off `window.innerWidth` read, so rotating the device switches the view.

**Nothing changes above 640px** — desktop is still the week grid with its legend, verified separately.

### Verification, on a 390px phone

| | |
|---|---|
| Agenda lists real lessons | `יום ראשון 6 בספטמבר · 16:00–16:45 אליהו כהן` |
| הוסף שיעור | dialog opens |
| אירוע אחר | dialog opens |
| Switch to month | available |
| Calendar starts at | **y=487**, was y=1090 |
| Page errors / sideways scroll | none |
| Desktop | week grid + legend unchanged |
| Tests | 165 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMWFQ4UFax82ABW3tK7k2L)_