### PR TITLE
Add open charges summary view for payment collection

### DIFF
--- a/backend/Talmidon.Api/Contracts/PaymentDtos.cs
+++ b/backend/Talmidon.Api/Contracts/PaymentDtos.cs
@@ -10,6 +10,18 @@ public record OpenChargeDto(
     DateTimeOffset LessonStartTime,
     decimal Amount);
 
+/// <summary>
+/// שורה אחת בטבלת "מי חייב כמה". <see cref="ParentId"/> ריק כשלשיעורים הפתוחים אין
+/// הורה משויך — כסף כזה אינו ניתן לגבייה במסך הזה, ולכן הוא מוצג ולא נבלע.
+/// </summary>
+public record OpenChargeSummaryDto(
+    Guid? ParentId,
+    string ParentName,
+    int StudentCount,
+    int LessonCount,
+    decimal Total,
+    DateTimeOffset OldestLessonStartTime);
+
 public record CreatePaymentRequest(
     [Required] Guid ParentId,
     [Required, MinLength(1)] List<Guid> LessonIds,

--- a/backend/Talmidon.Api/Controllers/PaymentsController.cs
+++ b/backend/Talmidon.Api/Controllers/PaymentsController.cs
@@ -56,6 +56,55 @@ public class PaymentsController(
         return Ok(charges);
     }
 
+    /// <summary>
+    /// "מי חייב כמה" — סיכום החיובים הפתוחים לפי הורה, כדי שהמורה תראה את התמונה
+    /// בלי לבחור הורה־הורה. תלמיד המשויך לשני הורים נספר פעם אחת בלבד, אצל ההורה
+    /// הראשון בסדר אלפביתי, כדי שהסכומים יסתכמו לסך החוב האמיתי.
+    /// </summary>
+    [Authorize(Roles = Roles.Teacher)]
+    [HttpGet("open-charges/summary")]
+    public async Task<ActionResult<IEnumerable<OpenChargeSummaryDto>>> OpenChargesSummary()
+    {
+        var charges = await db.Lessons
+            .Where(l => l.PaymentRequired && l.PaymentId == null)
+            .Select(l => new
+            {
+                l.StudentId,
+                l.StartTime,
+                l.Amount,
+                Parents = l.Student.StudentParents
+                    .Select(sp => new { sp.ParentId, sp.Parent.FullName })
+                    .ToList()
+            })
+            .ToListAsync();
+
+        var summary = charges
+            .Select(c =>
+            {
+                var payer = c.Parents.OrderBy(p => p.FullName).ThenBy(p => p.ParentId).FirstOrDefault();
+                return new
+                {
+                    ParentId = payer?.ParentId,
+                    ParentName = payer?.FullName ?? "ללא הורה משויך",
+                    c.StudentId,
+                    c.StartTime,
+                    c.Amount
+                };
+            })
+            .GroupBy(c => new { c.ParentId, c.ParentName })
+            .Select(g => new OpenChargeSummaryDto(
+                g.Key.ParentId,
+                g.Key.ParentName,
+                g.Select(c => c.StudentId).Distinct().Count(),
+                g.Count(),
+                g.Sum(c => c.Amount),
+                g.Min(c => c.StartTime)))
+            .OrderBy(s => s.OldestLessonStartTime)
+            .ToList();
+
+        return Ok(summary);
+    }
+
     [Authorize(Roles = Roles.Teacher)]
     [HttpGet]
     public async Task<ActionResult<IEnumerable<PaymentDto>>> List([FromQuery] Guid? parentId)

--- a/backend/Talmidon.Tests/OpenChargesSummaryTests.cs
+++ b/backend/Talmidon.Tests/OpenChargesSummaryTests.cs
@@ -1,0 +1,138 @@
+using System.Net.Http.Json;
+using Talmidon.Api.Contracts;
+
+namespace Talmidon.Tests;
+
+/// <summary>
+/// טבלת "מי חייב כמה". הסיכון האמיתי כאן הוא ספירה כפולה: תלמיד המשויך לשני הורים
+/// היה מופיע פעמיים ומנפח את סך החוב, ולכן הוא נספר אצל הורה אחד בלבד.
+/// </summary>
+[Collection(IntegrationTestCollection.Name)]
+public class OpenChargesSummaryTests(TalmidonWebApplicationFactory factory)
+{
+    [Fact]
+    public async Task Summary_GroupsOpenChargesByParent()
+    {
+        var teacher = await TestHelpers.CreateAuthorizedTeacherClientAsync(factory, "summaryByParent");
+        var studentId = await CreateStudentAsync(teacher, "תלמיד סיכום");
+        var parentId = await LinkParentAsync(teacher, studentId, "הורה סיכום");
+        await CreateChargeAsync(teacher, studentId, 120m, DateTimeOffset.UtcNow.AddDays(-3));
+        await CreateChargeAsync(teacher, studentId, 80m, DateTimeOffset.UtcNow.AddDays(-1));
+
+        var summary = await teacher.GetFromJsonAsync<List<OpenChargeSummaryDto>>("/api/payments/open-charges/summary");
+
+        var row = Assert.Single(summary!);
+        Assert.Equal(parentId, row.ParentId);
+        Assert.Equal(2, row.LessonCount);
+        Assert.Equal(1, row.StudentCount);
+        Assert.Equal(200m, row.Total);
+    }
+
+    [Fact]
+    public async Task Summary_CountsAStudentWithTwoParentsOnce()
+    {
+        var teacher = await TestHelpers.CreateAuthorizedTeacherClientAsync(factory, "summaryTwoParents");
+        var studentId = await CreateStudentAsync(teacher, "תלמיד שני הורים");
+        await LinkParentAsync(teacher, studentId, "אב");
+        await LinkParentAsync(teacher, studentId, "בת");
+        await CreateChargeAsync(teacher, studentId, 150m, DateTimeOffset.UtcNow.AddDays(-2));
+
+        var summary = await teacher.GetFromJsonAsync<List<OpenChargeSummaryDto>>("/api/payments/open-charges/summary");
+
+        var row = Assert.Single(summary!);
+        Assert.Equal(1, row.LessonCount);
+        Assert.Equal(150m, row.Total);
+    }
+
+    [Fact]
+    public async Task Summary_ShowsChargesOfAStudentWithNoParentInsteadOfHidingThem()
+    {
+        var teacher = await TestHelpers.CreateAuthorizedTeacherClientAsync(factory, "summaryNoParent");
+        var studentId = await CreateStudentAsync(teacher, "תלמיד ללא הורה");
+        await CreateChargeAsync(teacher, studentId, 90m, DateTimeOffset.UtcNow.AddDays(-5));
+
+        var summary = await teacher.GetFromJsonAsync<List<OpenChargeSummaryDto>>("/api/payments/open-charges/summary");
+
+        var row = Assert.Single(summary!);
+        Assert.Null(row.ParentId);
+        Assert.Equal(90m, row.Total);
+    }
+
+    [Fact]
+    public async Task Summary_IgnoresLessonsThatWereNotCharged()
+    {
+        var teacher = await TestHelpers.CreateAuthorizedTeacherClientAsync(factory, "summaryFreeLesson");
+        var studentId = await CreateStudentAsync(teacher, "תלמיד ניסיון");
+        await LinkParentAsync(teacher, studentId, "הורה ניסיון");
+        var lessonId = await CreateLessonAsync(teacher, studentId, DateTimeOffset.UtcNow.AddDays(-1));
+        var complete = await teacher.PostAsJsonAsync($"/api/lessons/{lessonId}/complete", new
+        {
+            completed = true,
+            paymentRequired = false,
+            amount = 0m,
+            noteVisibleToStudent = false,
+            noteVisibleToParent = false
+        });
+        complete.EnsureSuccessStatusCode();
+
+        var summary = await teacher.GetFromJsonAsync<List<OpenChargeSummaryDto>>("/api/payments/open-charges/summary");
+
+        Assert.Empty(summary!);
+    }
+
+    private static async Task<Guid> CreateStudentAsync(HttpClient teacher, string fullName)
+    {
+        var response = await teacher.PostAsJsonAsync("/api/students", new
+        {
+            fullName,
+            defaultPricePerLesson = 100m,
+            defaultDurationMinutes = 60
+        });
+        response.EnsureSuccessStatusCode();
+        var student = await response.Content.ReadFromJsonAsync<StudentDetailDto>();
+        return student!.Id;
+    }
+
+    private static async Task<Guid> LinkParentAsync(HttpClient teacher, Guid studentId, string fullName)
+    {
+        var created = await teacher.PostAsJsonAsync("/api/parents", new
+        {
+            fullName,
+            email = TestHelpers.UniqueEmail("summaryParent"),
+            phone = (string?)null
+        });
+        created.EnsureSuccessStatusCode();
+        var parent = await created.Content.ReadFromJsonAsync<ParentDto>();
+
+        var link = await teacher.PostAsync($"/api/students/{studentId}/parents/{parent!.Id}", null);
+        link.EnsureSuccessStatusCode();
+        return parent.Id;
+    }
+
+    private static async Task<Guid> CreateLessonAsync(HttpClient teacher, Guid studentId, DateTimeOffset start)
+    {
+        var response = await teacher.PostAsJsonAsync("/api/lessons", new
+        {
+            studentId,
+            startTime = start,
+            endTime = start.AddMinutes(60)
+        });
+        response.EnsureSuccessStatusCode();
+        var lesson = await response.Content.ReadFromJsonAsync<LessonDto>();
+        return lesson!.Id;
+    }
+
+    private static async Task CreateChargeAsync(HttpClient teacher, Guid studentId, decimal amount, DateTimeOffset start)
+    {
+        var lessonId = await CreateLessonAsync(teacher, studentId, start);
+        var response = await teacher.PostAsJsonAsync($"/api/lessons/{lessonId}/complete", new
+        {
+            completed = true,
+            paymentRequired = true,
+            amount,
+            noteVisibleToStudent = false,
+            noteVisibleToParent = false
+        });
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/frontend/src/app/features/payments/payments-list/payments-list.component.html
+++ b/frontend/src/app/features/payments/payments-list/payments-list.component.html
@@ -16,20 +16,105 @@
 
   <p-tabpanels>
     <p-tabpanel value="open">
-      <div class="field" style="max-width: 360px">
-        <label for="p-parent">הורה</label>
-        <p-select
-          inputId="p-parent"
-          [options]="parents()"
-          optionLabel="fullName"
-          optionValue="id"
-          placeholder="בחר הורה"
-          [ngModel]="selectedParentId()"
-          (ngModelChange)="selectedParentId.set($event); onParentChange()"
-          styleClass="w-full" />
-      </div>
+      @if (!selectedParentId()) {
+        <div class="owed-banner flex flex-wrap align-items-baseline gap-2 mb-3">
+          <span class="text-2xl font-bold">{{ totalOwed() | number: '1.0-2' }} ₪</span>
+          <span class="text-color-secondary">פתוחים לגבייה · {{ totalOpenLessons() }} שיעורים</span>
+        </div>
+
+        <div class="owed-table">
+        <p-table [value]="summary()" [loading]="summaryLoading()" dataKey="parentName">
+          <ng-template pTemplate="header">
+            <tr>
+              <th>הורה</th>
+              <th>שיעורים</th>
+              <th>ממתין מאז</th>
+              <th>סכום</th>
+              <th style="width: 10rem"></th>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="body" let-row>
+            <tr>
+              <td>
+                <div class="flex align-items-center gap-2">
+                  <span class="avatar-circle" style="width: 2.25rem; height: 2.25rem; font-size: 0.85rem" [style.--avatar-color]="avatarColor(row.parentName)">
+                    {{ initials(row.parentName) }}
+                  </span>
+                  <span>
+                    {{ row.parentName }}
+                    @if (row.studentCount > 1) {
+                      <small class="block text-color-secondary">{{ row.studentCount }} תלמידים</small>
+                    }
+                  </span>
+                </div>
+              </td>
+              <td>{{ row.lessonCount }}</td>
+              <td>
+                {{ row.oldestLessonStartTime | ilDate: 'dd/MM/yyyy' }}
+                <small class="block text-color-secondary">לפני {{ daysWaiting(row.oldestLessonStartTime) }} ימים</small>
+              </td>
+              <td class="font-bold">{{ row.total | number: '1.0-2' }} ₪</td>
+              <td>
+                @if (row.parentId) {
+                  <p-button label="גבייה" icon="pi pi-wallet" size="small" [text]="true" (onClick)="openParent(row)" />
+                } @else {
+                  <small class="text-color-secondary">אין הורה לשייך אליו תשלום</small>
+                }
+              </td>
+            </tr>
+          </ng-template>
+          <ng-template pTemplate="emptymessage">
+            <tr>
+              <td colspan="5">
+                <app-empty-state icon="pi-check-circle" title="אין חיובים פתוחים" hint="כל השיעורים שהתקיימו שולמו." />
+              </td>
+            </tr>
+          </ng-template>
+        </p-table>
+        </div>
+
+        <div class="owed-cards">
+          @for (row of summary(); track row.parentName) {
+            <div class="owed-card">
+              <div class="flex align-items-center gap-2 mb-2">
+                <span class="avatar-circle" style="width: 2.25rem; height: 2.25rem; font-size: 0.85rem" [style.--avatar-color]="avatarColor(row.parentName)">
+                  {{ initials(row.parentName) }}
+                </span>
+                <span class="font-medium">{{ row.parentName }}</span>
+                <span class="owed-card-amount font-bold">{{ row.total | number: '1.0-2' }} ₪</span>
+              </div>
+              <div class="text-color-secondary text-sm mb-2">
+                {{ row.lessonCount }} שיעורים · ממתין מאז {{ row.oldestLessonStartTime | ilDate: 'dd/MM/yyyy' }} ({{ daysWaiting(row.oldestLessonStartTime) }} ימים)
+              </div>
+              @if (row.parentId) {
+                <p-button label="גבייה" icon="pi pi-wallet" size="small" [outlined]="true" (onClick)="openParent(row)" />
+              } @else {
+                <small class="text-color-secondary">אין הורה לשייך אליו תשלום</small>
+              }
+            </div>
+          } @empty {
+            <app-empty-state icon="pi-check-circle" title="אין חיובים פתוחים" hint="כל השיעורים שהתקיימו שולמו." />
+          }
+        </div>
+
+      }
 
       @if (selectedParentId()) {
+        <div class="flex align-items-center justify-content-between flex-wrap gap-2 mb-3">
+          <p-button label="חזרה לכל ההורים" icon="pi pi-arrow-right" severity="secondary" [text]="true" (onClick)="backToSummary()" />
+          <div class="field m-0" style="min-width: 220px">
+            <p-select
+              inputId="p-parent"
+              [options]="parents()"
+              optionLabel="fullName"
+              optionValue="id"
+              placeholder="בחר הורה"
+              [ngModel]="selectedParentId()"
+              (ngModelChange)="selectedParentId.set($event); onParentChange()"
+              styleClass="w-full" />
+          </div>
+        </div>
+
         <p-table [value]="openCharges()" [loading]="openChargesLoading()" dataKey="lessonId" class="mt-3">
           <ng-template pTemplate="header">
             <tr>
@@ -40,7 +125,7 @@
                   (onChange)="toggleAll()" />
               </th>
               <th>תלמיד</th>
-              <th>תאריך שיעור</th>
+              <th class="charge-date-col">תאריך שיעור</th>
               <th>סכום</th>
             </tr>
           </ng-template>
@@ -51,14 +136,18 @@
               </td>
               <td>
                 <div class="flex align-items-center gap-2">
-                  <span class="avatar-circle" style="width: 2.25rem; height: 2.25rem; font-size: 0.85rem" [style.--avatar-color]="avatarColor(charge.studentName)">
+                  <span class="avatar-circle charge-avatar" style="width: 2.25rem; height: 2.25rem; font-size: 0.85rem" [style.--avatar-color]="avatarColor(charge.studentName)">
                     {{ initials(charge.studentName) }}
                   </span>
-                  {{ charge.studentName }}
+                  <span>
+                    {{ charge.studentName }}
+                    <!-- בטלפון עמודת התאריך מוסתרת, והתאריך יורד לכאן -->
+                    <small class="charge-date-inline text-color-secondary">{{ charge.lessonStartTime | ilDate: 'dd/MM/yyyy' }}</small>
+                  </span>
                 </div>
               </td>
-              <td>{{ charge.lessonStartTime | ilDate: 'dd/MM/yyyy' }}</td>
-              <td>{{ charge.amount }} ₪</td>
+              <td class="charge-date-col">{{ charge.lessonStartTime | ilDate: 'dd/MM/yyyy' }}</td>
+              <td>{{ charge.amount | number: '1.0-2' }} ₪</td>
             </tr>
           </ng-template>
           <ng-template pTemplate="emptymessage">
@@ -74,7 +163,7 @@
           <form [formGroup]="paymentForm" (ngSubmit)="markAsPaid()" class="mt-4" style="max-width: 480px">
             <div class="payment-summary-bar flex justify-content-between align-items-center mb-3">
               <span class="font-medium">סה"כ נבחר</span>
-              <span class="font-bold text-xl">{{ selectedTotal() }} ₪</span>
+              <span class="font-bold text-xl">{{ selectedTotal() | number: '1.0-2' }} ₪</span>
             </div>
             @if (noSelectionError()) {
               <small class="text-red-500 block mb-3">יש לבחור לפחות שיעור אחד</small>
@@ -143,7 +232,7 @@
                 {{ payment.parentName }}
               </div>
             </td>
-            <td>{{ payment.amount }} ₪</td>
+            <td>{{ payment.amount | number: '1.0-2' }} ₪</td>
             <td>{{ payment.paidDate | ilDate: 'dd/MM/yyyy' }}</td>
             <td>{{ payment.method || '—' }}</td>
             <td>{{ payment.lessonCount }}</td>

--- a/frontend/src/app/features/payments/payments-list/payments-list.component.ts
+++ b/frontend/src/app/features/payments/payments-list/payments-list.component.ts
@@ -1,4 +1,5 @@
 
+import { DecimalPipe } from '@angular/common';
 import { Component, OnInit, computed, inject, signal } from '@angular/core';
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ConfirmationService, MessageService } from 'primeng/api';
@@ -17,7 +18,7 @@ import { fieldError, isInvalid } from '../../../core/forms/validation-messages';
 import { getAvatarColor, getInitials } from '../../../shared/avatar/avatar.util';
 import { Parent } from '../../parents/parents.models';
 import { ParentsService } from '../../parents/parents.service';
-import { OpenCharge, Payment } from '../payments.models';
+import { OpenCharge, OpenChargeSummary, Payment } from '../payments.models';
 import { PaymentsService } from '../payments.service';
 import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
 
@@ -32,7 +33,7 @@ import { IsraelDatePipe } from '../../../core/i18n/israel-date.pipe';
     SelectModule,
     TableModule,
     TabsModule,
-    TagModule, PageHeaderComponent, EmptyStateComponent, IsraelDatePipe],
+    TagModule, PageHeaderComponent, EmptyStateComponent, IsraelDatePipe, DecimalPipe],
   templateUrl: './payments-list.component.html'
 })
 export class PaymentsListComponent implements OnInit {
@@ -46,6 +47,9 @@ export class PaymentsListComponent implements OnInit {
   protected readonly avatarColor = getAvatarColor;
 
   protected readonly parents = signal<Parent[]>([]);
+  /** "מי חייב כמה" — התמונה שנפתחת ראשונה, לפני שבוחרים הורה מסוים. */
+  protected readonly summary = signal<OpenChargeSummary[]>([]);
+  protected readonly summaryLoading = signal(true);
   protected readonly selectedParentId = signal<string | null>(null);
   protected readonly openCharges = signal<OpenCharge[]>([]);
   protected readonly openChargesLoading = signal(false);
@@ -58,6 +62,9 @@ export class PaymentsListComponent implements OnInit {
   protected readonly noSelectionError = signal(false);
   protected readonly fieldError = fieldError;
   protected readonly isInvalid = isInvalid;
+
+  protected readonly totalOwed = computed(() => this.summary().reduce((sum, row) => sum + row.total, 0));
+  protected readonly totalOpenLessons = computed(() => this.summary().reduce((sum, row) => sum + row.lessonCount, 0));
 
   protected readonly selectedTotal = computed(() => {
     const ids = this.selectedLessonIds();
@@ -74,7 +81,37 @@ export class PaymentsListComponent implements OnInit {
 
   ngOnInit(): void {
     this.parentsService.list().subscribe(parents => this.parents.set(parents));
+    this.loadSummary();
     this.loadPayments();
+  }
+
+  private loadSummary(): void {
+    this.summaryLoading.set(true);
+    this.paymentsService.openChargesSummary().subscribe({
+      next: rows => {
+        this.summary.set(rows);
+        this.summaryLoading.set(false);
+      },
+      error: () => this.summaryLoading.set(false)
+    });
+  }
+
+  /** לחיצה על שורה בטבלת החוב — פותחת את החיובים של אותו הורה. */
+  openParent(row: OpenChargeSummary): void {
+    if (!row.parentId) return;
+    this.selectedParentId.set(row.parentId);
+    this.onParentChange();
+  }
+
+  backToSummary(): void {
+    this.selectedParentId.set(null);
+    this.onParentChange();
+  }
+
+  /** כמה ימים עברו מהשיעור הפתוח הוותיק ביותר — חוב של חודש נראה אחרת מחוב של אתמול. */
+  daysWaiting(isoDate: string): number {
+    const days = Math.floor((Date.now() - new Date(isoDate).getTime()) / 86_400_000);
+    return days > 0 ? days : 0;
   }
 
   onParentChange(): void {
@@ -89,6 +126,8 @@ export class PaymentsListComponent implements OnInit {
     this.paymentsService.openCharges(parentId).subscribe({
       next: charges => {
         this.openCharges.set(charges);
+        // המורה נכנסה כדי לגבות — הכול מסומן, והיא מורידה סימון מהחריגים
+        this.selectedLessonIds.set(new Set(charges.map(c => c.lessonId)));
         this.openChargesLoading.set(false);
       },
       error: () => this.openChargesLoading.set(false)
@@ -138,6 +177,7 @@ export class PaymentsListComponent implements OnInit {
           this.messageService.add({ severity: 'success', summary: 'התשלום נרשם ונשלח אישור להורה' });
           this.paymentForm.reset({ paidDate: new Date(), method: '', note: '' });
           this.onParentChange();
+          this.loadSummary();
           this.loadPayments();
         },
         error: err => {
@@ -177,6 +217,7 @@ export class PaymentsListComponent implements OnInit {
     this.paymentsService.delete(id).subscribe({
       next: () => {
         this.messageService.add({ severity: 'success', summary: 'התשלום בוטל' });
+        this.loadSummary();
         this.loadPayments();
         if (this.selectedParentId()) this.onParentChange();
       },

--- a/frontend/src/app/features/payments/payments.models.ts
+++ b/frontend/src/app/features/payments/payments.models.ts
@@ -6,6 +6,16 @@ export interface OpenCharge {
   amount: number;
 }
 
+/** שורה בטבלת "מי חייב כמה". parentId ריק = שיעורים של תלמידים ללא הורה משויך. */
+export interface OpenChargeSummary {
+  parentId: string | null;
+  parentName: string;
+  studentCount: number;
+  lessonCount: number;
+  total: number;
+  oldestLessonStartTime: string;
+}
+
 export interface CreatePaymentRequest {
   parentId: string;
   lessonIds: string[];

--- a/frontend/src/app/features/payments/payments.service.ts
+++ b/frontend/src/app/features/payments/payments.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { CreatePaymentRequest, OpenCharge, Payment, PaymentDetail } from './payments.models';
+import { CreatePaymentRequest, OpenCharge, OpenChargeSummary, Payment, PaymentDetail } from './payments.models';
 
 @Injectable({ providedIn: 'root' })
 export class PaymentsService {
@@ -14,6 +14,11 @@ export class PaymentsService {
     let params = new HttpParams();
     if (parentId) params = params.set('parentId', parentId);
     return this.http.get<OpenCharge[]>(`${this.api}/open-charges`, { params });
+  }
+
+  /** סיכום החוב הפתוח לפי הורה — מה שנטען כשנכנסים למסך. */
+  openChargesSummary(): Observable<OpenChargeSummary[]> {
+    return this.http.get<OpenChargeSummary[]>(`${this.api}/open-charges/summary`);
   }
 
   list(): Observable<Payment[]> {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -673,6 +673,48 @@ a.stat-card:hover {
   padding: 0.75rem 1rem;
 }
 
+/**
+ * טבלת "מי חייב כמה" מול כרטיסים: חמש עמודות אינן נכנסות לרוחב טלפון, ושם
+ * עמודת הסכום וכפתור הגבייה נחתכים — בדיוק מה שבאים למסך הזה בשבילו. לכן
+ * בטלפון אותם נתונים מוצגים ככרטיסים.
+ */
+.owed-cards { display: none; }
+
+@media (max-width: 640px) {
+  .owed-table { display: none; }
+  .owed-cards { display: block; }
+}
+
+.owed-card {
+  border: 1px solid var(--p-content-border-color);
+  border-radius: var(--p-border-radius-lg);
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
+/** הסכום נדחף לקצה הנגדי של שם ההורה. */
+.owed-card-amount { margin-inline-start: auto; }
+
+/**
+ * טבלת החיובים של הורה: ארבע עמודות חותכות בטלפון דווקא את עמודת הסכום, ולכן
+ * שם התאריך יורד מתחת לשם התלמיד והאווטאר יורד לגמרי.
+ */
+.charge-date-inline { display: none; }
+
+@media (max-width: 640px) {
+  .charge-date-col { display: none; }
+  .charge-date-inline { display: block; }
+  .charge-avatar { display: none; }
+}
+
+/** סך החוב הפתוח, בראש מסך התשלומים — המספר שהמורה באה לראות. */
+.owed-banner {
+  background: color-mix(in srgb, var(--p-primary-color) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--p-primary-color) 25%, transparent);
+  border-radius: var(--p-border-radius-lg);
+  padding: 0.75rem 1rem;
+}
+
 /* --------------------------------------------------------------- טבלאות ---- */
 
 /* טבלאות בפריסתן הרגילה נדחסות למחיקות על מסך צר — עדיף גלילה אופקית מודעת


### PR DESCRIPTION
## Summary
This PR adds a new "who owes what" summary view to the payments page, allowing teachers to see an overview of all open charges grouped by parent before selecting a specific parent for payment collection.

## Key Changes

**Backend:**
- Added `OpenChargesSummary()` endpoint (`GET /api/payments/open-charges/summary`) that returns aggregated open charges grouped by parent
- Implements deduplication logic: students linked to multiple parents are counted only once (assigned to the first parent alphabetically) to prevent double-counting debt
- Created `OpenChargeSummaryDto` contract with parent info, student count, lesson count, total amount, and oldest lesson date

**Frontend:**
- Added summary view as the default landing page in the payments tab, showing:
  - Total owed amount and lesson count in a banner
  - Table view (desktop) and card view (mobile) of charges by parent
  - Parent avatars with initials and student count when applicable
  - "Days waiting" calculation for each parent's oldest open charge
  - "Collect" button to drill into individual parent's charges
- Modified charge list view to show a "back to summary" button when a parent is selected
- Auto-selects all charges when opening a parent's detail view (teacher can deselect exceptions)
- Refreshes summary after payment is recorded or deleted
- Added responsive design: table on desktop, cards on mobile (max-width: 640px)
- Handles edge case of charges with no linked parent (displays as "ללא הורה משויך")

**Styling:**
- Added `.owed-banner` for the summary header with primary color accent
- Added `.owed-cards` and `.owed-card` for mobile card layout
- Added responsive media queries to hide table columns and show inline dates on mobile
- Improved number formatting with `DecimalPipe` for currency display

## Notable Implementation Details
- The summary endpoint uses LINQ to group charges and select the first parent alphabetically, ensuring consistent assignment of multi-parent students
- The frontend uses Angular signals for reactive state management of summary data
- Mobile-first responsive design hides the full table and shows cards instead on narrow viewports
- Date calculations use millisecond-based math for "days waiting" display

